### PR TITLE
Add workflow to enforce only develop merges into main

### DIFF
--- a/.github/workflows/only-develop-to-main.yml
+++ b/.github/workflows/only-develop-to-main.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo "Base: ${{ github.base_ref }}"
           echo "Head: ${{ github.head_ref }}"
-          if [ "${{ github.base_ref }}" = "main" ] && [ "${{ github.head_ref }}" != "develop" ]; then
+          if [ "${{ github.head_ref }}" != "develop" ]; then
             echo "❌ Only 'develop' may be merged into 'main'. Current head: '${{ github.head_ref }}'."
             exit 1
           fi

--- a/.github/workflows/only-develop-to-main.yml
+++ b/.github/workflows/only-develop-to-main.yml
@@ -1,0 +1,24 @@
+name: Enforce develop → main only
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  gate:
+    name: Branch gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block if head branch is not develop
+        run: |
+          echo "Base: ${{ github.base_ref }}"
+          echo "Head: ${{ github.head_ref }}"
+          if [ "${{ github.base_ref }}" = "main" ] && [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "❌ Only 'develop' may be merged into 'main'. Current head: '${{ github.head_ref }}'."
+            exit 1
+          fi
+          echo "✅ develop → main allowed."
+

--- a/.github/workflows/only-develop-to-main.yml
+++ b/.github/workflows/only-develop-to-main.yml
@@ -20,4 +20,3 @@ jobs:
             echo "❌ Only 'develop' may be merged into 'main'. Current head: '${{ github.head_ref }}'."
             exit 1
           fi
-

--- a/.github/workflows/only-develop-to-main.yml
+++ b/.github/workflows/only-develop-to-main.yml
@@ -18,5 +18,6 @@ jobs:
           echo "Head: ${{ github.head_ref }}"
           if [ "${{ github.head_ref }}" != "develop" ]; then
             echo "❌ Only 'develop' may be merged into 'main'. Current head: '${{ github.head_ref }}'."
+            echo "👉 To merge your changes, please create a pull request from your feature branch to 'develop' first, then merge 'develop' into 'main'."
             exit 1
           fi

--- a/.github/workflows/only-develop-to-main.yml
+++ b/.github/workflows/only-develop-to-main.yml
@@ -20,5 +20,4 @@ jobs:
             echo "❌ Only 'develop' may be merged into 'main'. Current head: '${{ github.head_ref }}'."
             exit 1
           fi
-          echo "✅ develop → main allowed."
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce that only the `develop` branch can be merged into `main`. This helps maintain a clean and controlled release process by preventing unauthorized branches from being merged into the main production branch.

Branch protection and workflow enforcement:

* Added `.github/workflows/only-develop-to-main.yml` to block pull requests targeting `main` unless the source branch is `develop`. The workflow checks the base and head branches and fails the action if the head is not `develop`.