### PR TITLE
Put the new rules to prevent issues with Merging with Main

### DIFF
--- a/.github/workflows/only-develop-to-main.yml
+++ b/.github/workflows/only-develop-to-main.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo "Base: ${{ github.base_ref }}"
           echo "Head: ${{ github.head_ref }}"
-          if [ "${{ github.base_ref }}" = "main" ] && [ "${{ github.head_ref }}" != "develop" ]; then
+          if [ "${{ github.head_ref }}" != "develop" ]; then
             echo "❌ Only 'develop' may be merged into 'main'. Current head: '${{ github.head_ref }}'."
             exit 1
           fi

--- a/.github/workflows/only-develop-to-main.yml
+++ b/.github/workflows/only-develop-to-main.yml
@@ -1,0 +1,24 @@
+name: Enforce develop → main only
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  gate:
+    name: Branch gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block if head branch is not develop
+        run: |
+          echo "Base: ${{ github.base_ref }}"
+          echo "Head: ${{ github.head_ref }}"
+          if [ "${{ github.base_ref }}" = "main" ] && [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "❌ Only 'develop' may be merged into 'main'. Current head: '${{ github.head_ref }}'."
+            exit 1
+          fi
+          echo "✅ develop → main allowed."
+

--- a/.github/workflows/only-develop-to-main.yml
+++ b/.github/workflows/only-develop-to-main.yml
@@ -20,4 +20,3 @@ jobs:
             echo "❌ Only 'develop' may be merged into 'main'. Current head: '${{ github.head_ref }}'."
             exit 1
           fi
-

--- a/.github/workflows/only-develop-to-main.yml
+++ b/.github/workflows/only-develop-to-main.yml
@@ -18,5 +18,6 @@ jobs:
           echo "Head: ${{ github.head_ref }}"
           if [ "${{ github.head_ref }}" != "develop" ]; then
             echo "❌ Only 'develop' may be merged into 'main'. Current head: '${{ github.head_ref }}'."
+            echo "👉 To merge your changes, please create a pull request from your feature branch to 'develop' first, then merge 'develop' into 'main'."
             exit 1
           fi

--- a/.github/workflows/only-develop-to-main.yml
+++ b/.github/workflows/only-develop-to-main.yml
@@ -20,5 +20,4 @@ jobs:
             echo "❌ Only 'develop' may be merged into 'main'. Current head: '${{ github.head_ref }}'."
             exit 1
           fi
-          echo "✅ develop → main allowed."
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce a stricter branching policy for merges into the `main` branch. The workflow ensures that only pull requests originating from the `develop` branch can be merged into `main`, helping maintain a clean and controlled release process.

Branch protection workflow:

* Added `.github/workflows/only-develop-to-main.yml` to block pull requests to `main` unless the source branch is `develop`, with clear messaging for contributors who attempt to merge from other branches.