### PR TITLE
Creation of the Bipolar Bar to visualize indoor-outdoor scores

### DIFF
--- a/Swifties/Components/Profile/ProfileHeader.swift
+++ b/Swifties/Components/Profile/ProfileHeader.swift
@@ -131,7 +131,7 @@ private struct BipolarProgressBar: View {
                 Circle()
                     .fill(Color.black.opacity(0.6))
                     .frame(width: height, height: height)
-                    .offset(x: mid + floatValue)
+                    .offset(x: mid * (1 + floatValue), y: height/2)
             }
         }
         .frame(height: height)

--- a/Swifties/Components/Profile/ProfileHeader.swift
+++ b/Swifties/Components/Profile/ProfileHeader.swift
@@ -13,7 +13,13 @@ struct ProfileHeader: View {
     let name: String
     let major: String
     let age: Int
-    let indoor_outdoor_score: String
+    let indoor_outdoor_score: Int
+    
+    private var personalityLabel: String {
+        if indoor_outdoor_score < 0 { return "Insider" }
+        if indoor_outdoor_score > 0 { return "Outsider" }
+        return "Neutral"
+    }
     
     var body: some View {
         HStack(spacing: 20) {
@@ -66,20 +72,68 @@ struct ProfileHeader: View {
                 
                 Text("Major - \(major)")
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(.black)
                 
                 Text("Age - \(age)")
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(.black)
                 
-                Text("Personality score - \(indoor_outdoor_score)")
+                Text("Personality: \(personalityLabel) (\(indoor_outdoor_score))")
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(.black)
+                
+                BipolarProgressBar(value: indoor_outdoor_score)
             }
             
             Spacer()
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 20)
+    }
+}
+
+// MARK: - Bipolar progress bar (-100 to 100) starting at center
+private struct BipolarProgressBar: View {
+    let value: Int // expected range: -100...100
+    var height: CGFloat = 8
+    var negativeColor: Color = Color("appRed")
+    var positiveColor: Color = Color("appBlue")
+    
+    var body: some View {
+        GeometryReader { geo in
+            let mid = geo.size.width / 2
+            let floatValue = (CGFloat(value) / 100.0)
+            let magnitude = min(max(abs(CGFloat(value)) / 100.0, 0), 1)
+            let fillW = mid * magnitude
+            ZStack(alignment: .leading) {
+                // Track
+                Capsule()
+                    .fill(Color.secondary.opacity(0.2))
+                    .frame(height: height + 2)
+                
+                // Fill from center to the right for positive values
+                if value > 0 {
+                    Capsule()
+                        .fill(positiveColor)
+                        .frame(width: fillW, height: height)
+                        .offset(x: mid)
+                }
+                
+                // Fill from center to the left for negative values
+                if value < 0 {
+                    Capsule()
+                        .fill(negativeColor)
+                        .frame(width: fillW, height: height)
+                        .offset(x: mid - fillW)
+                }
+                
+                // Center tick
+                Circle()
+                    .fill(Color.black.opacity(0.6))
+                    .frame(width: height, height: height)
+                    .offset(x: mid + floatValue)
+            }
+        }
+        .frame(height: height)
     }
 }

--- a/Swifties/Models/UserProfile.swift
+++ b/Swifties/Models/UserProfile.swift
@@ -15,6 +15,6 @@ struct UserProfile: Identifiable, Equatable {
     let avatar_url: String?
     let major: String
     let age: Int
-    let indoor_outdoor_score: String
+    let indoor_outdoor_score: Int
     let preferences: [String]
 }

--- a/Swifties/ViewModels/ProfileViewModel.swift
+++ b/Swifties/ViewModels/ProfileViewModel.swift
@@ -60,7 +60,13 @@ final class UserProfileRepository {
             return 0
         }()
 
-        let personality = profile["indoor_outdoor_score"] as? String ?? "Unknown"
+        let personality: Int = {
+            if let v = profile["indoor_outdoor_score"] as? Int { return v }
+            if let v = profile["indoor_outdoor_score"] as? NSNumber { return v.intValue }
+            if let v = profile["indoor_outdoor_score"] as? Double { return Int(v) }
+            return 0
+        }()
+        
         let preferences = profile["favorite_categories"] as? [String] ?? ["Unknown"]
 
         // Image resolution priority: imageURL (absolute) -> imagePath (resolve via Storage)


### PR DESCRIPTION
This pull request updates the user profile's personality score system and enhances its presentation in the profile UI. The main improvements include changing the data type of `indoor_outdoor_score` from `String` to `Int` for consistency, introducing a new visual indicator for personality, and improving the display logic in the profile header.

**Profile Data Model and Parsing Updates:**

* Changed the `indoor_outdoor_score` property in both `UserProfile` and its parsing logic from `String` to `Int`, ensuring type consistency and simplifying downstream usage. [[1]](diffhunk://#diff-7f29db0ac23b1652d03068421c8fd7eac7cd8d7977fdd4c2367c1886756b1920L18-R18) [[2]](diffhunk://#diff-c2ee486c9a4006b9ec7c7fd2e0f2956a87237fcf5fdab8b63f8eac51a63a66efL63-R69)

**Profile Header UI Enhancements:**

* Updated the `ProfileHeader` to use the new `Int` score, added a computed label (`Insider`, `Outsider`, or `Neutral`) based on the score, and improved the display text for personality. [[1]](diffhunk://#diff-c18f6dc23413408958f3bc593db7b5563e6e95ef05dcd5e1d107fc860eca165fL16-R22) [[2]](diffhunk://#diff-c18f6dc23413408958f3bc593db7b5563e6e95ef05dcd5e1d107fc860eca165fL69-R85)
* Introduced a new `BipolarProgressBar` SwiftUI component that visually represents the `indoor_outdoor_score` on a scale from -100 to 100, providing a clearer and more engaging way to convey the user's personality orientation.
* Changed the color of profile detail texts from `.secondary` to `.black` for better readability.