### PR TITLE
Addition of bipolar bar with visualization data for type 2 BQ

### DIFF
--- a/Swifties/Components/Profile/ProfileHeader.swift
+++ b/Swifties/Components/Profile/ProfileHeader.swift
@@ -1,4 +1,5 @@
 //
+//
 //  ProfileHeader.swift
 //  Swifties
 //
@@ -13,7 +14,13 @@ struct ProfileHeader: View {
     let name: String
     let major: String
     let age: Int
-    let indoor_outdoor_score: String
+    let indoor_outdoor_score: Int
+    
+    private var personalityLabel: String {
+        if indoor_outdoor_score < 0 { return "Insider" }
+        if indoor_outdoor_score > 0 { return "Outsider" }
+        return "Neutral"
+    }
     
     var body: some View {
         HStack(spacing: 20) {
@@ -66,20 +73,68 @@ struct ProfileHeader: View {
                 
                 Text("Major - \(major)")
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(.black)
                 
                 Text("Age - \(age)")
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(.black)
                 
-                Text("Personality score - \(indoor_outdoor_score)")
+                Text("Personality: \(personalityLabel) (\(abs(indoor_outdoor_score))%)")
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(.black)
+                
+                BipolarProgressBar(value: indoor_outdoor_score)
             }
             
             Spacer()
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 20)
+    }
+}
+
+// MARK: - Bipolar progress bar (-100 to 100) starting at center
+private struct BipolarProgressBar: View {
+    let value: Int // expected range: -100...100
+    var height: CGFloat = 8
+    var negativeColor: Color = Color("appRed")
+    var positiveColor: Color = Color("appBlue")
+    
+    var body: some View {
+        GeometryReader { geo in
+            let mid = geo.size.width / 2
+            let floatValue = (CGFloat(value) / 100.0)
+            let magnitude = min(max(abs(CGFloat(value)) / 100.0, 0), 1)
+            let fillW = mid * magnitude
+            ZStack(alignment: .leading) {
+                // Track
+                Capsule()
+                    .fill(Color.secondary.opacity(0.2))
+                    .frame(height: height + 2)
+                
+                // Fill from center to the right for positive values
+                if value > 0 {
+                    Capsule()
+                        .fill(positiveColor)
+                        .frame(width: fillW, height: height)
+                        .offset(x: mid)
+                }
+                
+                // Fill from center to the left for negative values
+                if value < 0 {
+                    Capsule()
+                        .fill(negativeColor)
+                        .frame(width: fillW, height: height)
+                        .offset(x: mid - fillW)
+                }
+                
+                // Center tick
+                Circle()
+                    .fill(Color.black.opacity(0.6))
+                    .frame(width: height, height: height)
+                    .offset(x: mid * (1 + floatValue), y: height/2)
+            }
+        }
+        .frame(height: height)
     }
 }

--- a/Swifties/Components/Profile/ProfileHeader.swift
+++ b/Swifties/Components/Profile/ProfileHeader.swift
@@ -1,8 +1,5 @@
 //
 //
-//  ProfileHeader.swift
-//  Swifties
-//
 //  Created by Natalia Villegas Calderón on 27/09/25.
 //
 


### PR DESCRIPTION
This pull request updates the `ProfileHeader` component to improve how the user's personality score is represented. Instead of displaying a raw score, it now shows a more user-friendly label and a visual progress bar. Additionally, some UI color choices have been updated for better clarity.

**Profile score display improvements:**

* Changed `indoor_outdoor_score` from a `String` to an `Int` and added a computed `personalityLabel` property to map the score to "Insider", "Outsider", or "Neutral". The UI now displays the label and the absolute score percentage, instead of the raw value. [[1]](diffhunk://#diff-c18f6dc23413408958f3bc593db7b5563e6e95ef05dcd5e1d107fc860eca165fL16-R23) [[2]](diffhunk://#diff-c18f6dc23413408958f3bc593db7b5563e6e95ef05dcd5e1d107fc860eca165fL69-R86)
* Added a new `BipolarProgressBar` component to visually represent the personality score, with color-coded progress from center (neutral) to either end.

**UI enhancements:**

* Changed the text color for major, age, and personality score from `.secondary` to `.black` for better visibility.