### PR TITLE
Fixed small details for the UI/UX

### DIFF
--- a/Swifties/MainView.swift
+++ b/Swifties/MainView.swift
@@ -24,8 +24,10 @@ struct MainView: View {
     
     // MARK: - Private Views
     @ViewBuilder
-    private func contentView(for tab: Int) -> some View {
+    private func contentView(for tab: Int) ->
+    some View {
         switch tab {
+            
         case 0:
             HomeView()
         case 1:

--- a/Swifties/MainView.swift
+++ b/Swifties/MainView.swift
@@ -24,8 +24,7 @@ struct MainView: View {
     
     // MARK: - Private Views
     @ViewBuilder
-    private func contentView(for tab: Int) ->
-    some View {
+    private func contentView(for tab: Int) -> some View {
         switch tab {
             
         case 0:

--- a/Swifties/Views/RegisterView.swift
+++ b/Swifties/Views/RegisterView.swift
@@ -624,6 +624,7 @@ struct RegisterView: View {
     // Helper: end of day for given date (keeps selection within same day)
     private func endOfDay(for date: Date) -> Date {
         let cal = Calendar.current
-        return cal.date(bySettingHour: 23, minute: 59, second: 59, of: date) ?? date
+        // Set end of day to 23:59:00 to avoid confusion in time selection UI
+        return cal.date(bySettingHour: 23, minute: 59, second: 0, of: date) ?? date
     }
 }

--- a/Swifties/Views/RegisterView.swift
+++ b/Swifties/Views/RegisterView.swift
@@ -413,7 +413,8 @@ struct RegisterView: View {
                         .onChange(of: viewModel.startTime) { oldStart, newStart in
                             // Ensure end is always after start; bump end forward if needed
                             if viewModel.endTime <= newStart {
-                                viewModel.endTime = Calendar.current.date(byAdding: .minute, value: 30, to: newStart) ?? newStart
+                                viewModel.endTime = Calendar.current.date(byAdding: .minute, value: 30, to: newStart)
+                                    ?? Calendar.current.date(byAdding: .minute, value: 1, to: newStart)!
                             }
                         }
                     

--- a/Swifties/Views/RegisterView.swift
+++ b/Swifties/Views/RegisterView.swift
@@ -414,7 +414,8 @@ struct RegisterView: View {
                             // Ensure end is always after start; bump end forward if needed
                             if viewModel.endTime <= newStart {
                                 viewModel.endTime = Calendar.current.date(byAdding: .minute, value: 30, to: newStart)
-                                    ?? Calendar.current.date(byAdding: .minute, value: 1, to: newStart)!
+                                    ?? Calendar.current.date(byAdding: .minute, value: 1, to: newStart)
+                                    ?? newStart
                             }
                         }
                     

--- a/Swifties/Views/RegisterView.swift
+++ b/Swifties/Views/RegisterView.swift
@@ -74,19 +74,22 @@ struct RegisterView: View {
                 
                 HStack(spacing: 16) {
                     Button(action: handleNext) {
-                        if viewModel.isLoading {
-                            ProgressView()
-                                .tint(.white)
-                        } else {
-                            Text(currentStep == 4 ? "Save" : "Next")
-                                .font(.system(size: 16, weight: .semibold))
+                        HStack {
+                            if viewModel.isLoading {
+                                ProgressView()
+                                    .tint(.white)
+                            } else {
+                                Text(currentStep == 4 ? "Save" : "Next")
+                                    .font(.system(size: 16, weight: .semibold))
+                            }
                         }
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(Color.appRed)
+                        .cornerRadius(12)
+                        .contentShape(Rectangle())
                     }
-                    .foregroundColor(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 16)
-                    .background(Color.appRed)
-                    .cornerRadius(12)
                     .disabled(viewModel.isLoading)
                 }
                 .padding(.horizontal, 24)
@@ -111,15 +114,6 @@ struct RegisterView: View {
                         .foregroundColor(.appRed)
                     }
                 }
-            }
-            
-            ToolbarItemGroup(placement: .keyboard) {
-                Spacer()
-                Button("Done") {
-                    focusedField = nil
-                }
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(.appRed)
             }
         }
         .alert("Error", isPresented: $showAlert) {
@@ -407,7 +401,7 @@ struct RegisterView: View {
                         .stroke(Color.gray.opacity(0.3), lineWidth: 1)
                 )
                 
-                HStack(spacing: 12) {
+                HStack(spacing: 10) {
                     DatePicker("Start", selection: $viewModel.startTime, displayedComponents: .hourAndMinute)
                         .padding()
                         .background(Color.white)
@@ -416,18 +410,35 @@ struct RegisterView: View {
                             RoundedRectangle(cornerRadius: 12)
                                 .stroke(Color.gray.opacity(0.3), lineWidth: 1)
                         )
+                        .onChange(of: viewModel.startTime) { oldStart, newStart in
+                            // Ensure end is always after start; bump end forward if needed
+                            if viewModel.endTime <= newStart {
+                                viewModel.endTime = Calendar.current.date(byAdding: .minute, value: 30, to: newStart) ?? newStart
+                            }
+                        }
                     
-                    DatePicker("End", selection: $viewModel.endTime, displayedComponents: .hourAndMinute)
-                        .padding()
-                        .background(Color.white)
-                        .cornerRadius(12)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                        )
+                    DatePicker(
+                        "End",
+                        selection: $viewModel.endTime,
+                        in: viewModel.startTime...endOfDay(for: viewModel.startTime),
+                        displayedComponents: .hourAndMinute
+                    )
+                    .padding()
+                    .background(Color.white)
+                    .cornerRadius(12)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                    )
                 }
                 
                 Button(action: {
+                    // Validate end > start before adding
+                    if viewModel.endTime <= viewModel.startTime {
+                        alertMessage = "End time must be after the start time."
+                        showAlert = true
+                        return
+                    }
                     viewModel.addFreeTimeSlot()
                 }) {
                     HStack {
@@ -458,7 +469,7 @@ struct RegisterView: View {
                                 Text(slot["day"] ?? "")
                                     .font(.system(size: 14, weight: .semibold))
                                 Text("\(slot["start"] ?? "") - \(slot["end"] ?? "")")
-                                    .font(.system(size: 11))
+                                    .font(.system(size: 12))
                                     .foregroundColor(.gray)
                             }
                             
@@ -606,5 +617,11 @@ struct RegisterView: View {
                 currentStep += 1
             }
         }
+    }
+    
+    // Helper: end of day for given date (keeps selection within same day)
+    private func endOfDay(for date: Date) -> Date {
+        let cal = Calendar.current
+        return cal.date(bySettingHour: 23, minute: 59, second: 59, of: date) ?? date
     }
 }


### PR DESCRIPTION
This pull request primarily improves the user experience and reliability of the free time slot selection in the registration flow. The most important changes include enforcing that the end time is always after the start time, adding validation and constraints to the date pickers, and making minor UI adjustments for consistency.

**Free time slot validation and constraints:**
* The end time picker now restricts selectable times to be after the chosen start time and within the same day, preventing users from selecting invalid ranges. (`Swifties/Views/RegisterView.swift`)
* When the start time is changed, the end time is automatically updated if necessary to ensure it remains after the start time. (`Swifties/Views/RegisterView.swift`)
* Added a check before adding a free time slot to display an alert if the end time is not after the start time. (`Swifties/Views/RegisterView.swift`)
* Introduced a helper method `endOfDay(for:)` to keep the end time selection within the same day. (`Swifties/Views/RegisterView.swift`)

**UI and interaction improvements:**
* Minor UI tweaks: Adjusted spacing in the free time slot picker, increased font size for slot times, and wrapped the loading indicator and button label together for better alignment. (`Swifties/Views/RegisterView.swift`) 

**Code formatting:**
* Small formatting change to the `contentView` method signature for readability. (`Swifties/MainView.swift`)