### PR TITLE
Weekly challenge

### DIFF
--- a/Swifties/MainView.swift
+++ b/Swifties/MainView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct MainView: View {
     
     // MARK: - Properties
-    @State private var selectedTab: Int = -1
+    @State private var selectedTab: Int = 0
     
     // MARK: - Body
     var body: some View {
@@ -31,7 +31,7 @@ struct MainView: View {
         case 1:
             EventListView(viewModel: EventListViewModel())
         default:
-            StartView()
+            HomeView()
         }
     }
 }

--- a/Swifties/MainView.swift
+++ b/Swifties/MainView.swift
@@ -30,6 +30,8 @@ struct MainView: View {
             HomeView()
         case 1:
             EventListView(viewModel: EventListViewModel())
+        case 2:
+            Magic8BallView() 
         default:
             HomeView()
         }

--- a/Swifties/SwiftiesApp.swift
+++ b/Swifties/SwiftiesApp.swift
@@ -42,7 +42,7 @@ struct SwiftiesApp: App {
         WindowGroup {
             NavigationStack {
                 if Auth.auth().currentUser != nil {
-                    HomeView()
+                    MainView()
                 }else{
                     StartView()
                 }

--- a/Swifties/Views/ActivityCompletion.swift
+++ b/Swifties/Views/ActivityCompletion.swift
@@ -1,0 +1,349 @@
+//
+//  ActivityCompletion.swift
+//  Swifties
+//
+//  Created by Imac  on 3/10/25.
+//
+
+import SwiftUI
+import FirebaseFirestore
+import Charts
+import Combine
+
+// MARK: - Activity Completion Model
+struct ActivityCompletion: Identifiable, Codable {
+    @DocumentID var id: String?
+    var userId: String
+    var activityId: String
+    var activityName: String
+    var completedAt: Date
+    var isWeeklyChallenge: Bool
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case userId = "user_id"
+        case activityId = "activity_id"
+        case activityName = "activity_name"
+        case completedAt = "completed_at"
+        case isWeeklyChallenge = "is_weekly_challenge"
+    }
+}
+
+// MARK: - Chart Data Model
+struct DailyCompletion: Identifiable {
+    let id = UUID()
+    let date: Date
+    let count: Int
+    
+    var dayLabel: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - ViewModel
+class WeeklyChallengeStatsViewModel: ObservableObject {
+    @Published var completions: [ActivityCompletion] = []
+    @Published var chartData: [DailyCompletion] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+    @Published var totalCompletions = 0
+    @Published var averagePerWeek = 0.0
+    
+    private let db = Firestore.firestore()
+    
+    func loadCompletions(userId: String) {
+        isLoading = true
+        errorMessage = nil
+        
+        let thirtyDaysAgo = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? Date()
+        
+        db.collection("activity_completions")
+            .whereField("user_id", isEqualTo: userId)
+            .whereField("is_weekly_challenge", isEqualTo: true)
+            .whereField("completed_at", isGreaterThanOrEqualTo: Timestamp(date: thirtyDaysAgo))
+            .order(by: "completed_at", descending: false)
+            .getDocuments { [weak self] snapshot, error in
+                DispatchQueue.main.async {
+                    self?.isLoading = false
+                    
+                    if let error = error {
+                        self?.errorMessage = "Error loading data: \(error.localizedDescription)"
+                        return
+                    }
+                    
+                    guard let documents = snapshot?.documents else {
+                        self?.errorMessage = "No data found"
+                        return
+                    }
+                    
+                    self?.completions = documents.compactMap { doc in
+                        try? doc.data(as: ActivityCompletion.self)
+                    }
+                    
+                    self?.processChartData()
+                }
+            }
+    }
+    
+    func processChartData() {
+        let calendar = Calendar.current
+        
+        var dailyCounts: [Date: Int] = [:]
+        
+        for completion in completions {
+            let dayStart = calendar.startOfDay(for: completion.completedAt)
+            dailyCounts[dayStart, default: 0] += 1
+        }
+        
+        var chartDataTemp: [DailyCompletion] = []
+        for dayOffset in 0..<30 {
+            if let date = calendar.date(byAdding: .day, value: -dayOffset, to: Date()) {
+                let dayStart = calendar.startOfDay(for: date)
+                let count = dailyCounts[dayStart] ?? 0
+                chartDataTemp.append(DailyCompletion(date: dayStart, count: count))
+            }
+        }
+        
+        chartData = chartDataTemp.reversed()
+        totalCompletions = completions.count
+        averagePerWeek = Double(totalCompletions) / 4.29
+    }
+}
+
+// MARK: - Main View
+struct WeeklyChallengeStatsView: View {
+    @StateObject private var viewModel = WeeklyChallengeStatsViewModel()
+    let userId: String
+    
+    var body: some View {
+        ZStack {
+            Color("appPrimary").ignoresSafeArea()
+            
+            VStack(spacing: 0) {
+                CustomTopBar(title: "Challenge Stats", showNotificationButton: false) {
+                    print("Back tapped")
+                }
+                
+                if viewModel.isLoading {
+                    Spacer()
+                    ProgressView("Loading stats…")
+                        .foregroundColor(.primary)
+                    Spacer()
+                } else if let error = viewModel.errorMessage {
+                    Spacer()
+                    VStack(spacing: 16) {
+                        Text("⚠️")
+                            .font(.system(size: 50))
+                        Text(error)
+                            .foregroundColor(.red)
+                            .multilineTextAlignment(.center)
+                            .padding()
+                        Button("Retry") {
+                            viewModel.loadCompletions(userId: userId)
+                        }
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                    }
+                    Spacer()
+                } else {
+                    ScrollView {
+                        VStack(spacing: 24) {
+                            
+                            HStack(spacing: 16) {
+                                StatCard(
+                                    title: "Total",
+                                    value: "\(viewModel.totalCompletions)",
+                                    icon: "checkmark.circle.fill",
+                                    color: .green
+                                )
+                                
+                                StatCard(
+                                    title: "Per Week",
+                                    value: String(format: "%.1f", viewModel.averagePerWeek),
+                                    icon: "calendar",
+                                    color: .orange
+                                )
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.top, 16)
+                            
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text("Last 30 Days")
+                                    .font(.title2)
+                                    .fontWeight(.bold)
+                                    .foregroundColor(.primary)
+                                    .padding(.horizontal, 16)
+                                
+                                if viewModel.chartData.isEmpty {
+                                    Text("No data to display")
+                                        .foregroundColor(.secondary)
+                                        .frame(maxWidth: .infinity)
+                                        .frame(height: 250)
+                                } else {
+                                    ChartView(data: viewModel.chartData)
+                                        .frame(height: 250)
+                                        .padding(.horizontal, 16)
+                                }
+                            }
+                            .padding(.vertical, 16)
+                            .background(Color(.systemBackground))
+                            .cornerRadius(16)
+                            .padding(.horizontal, 16)
+                            
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text("Recent Activities")
+                                    .font(.title2)
+                                    .fontWeight(.bold)
+                                    .foregroundColor(.primary)
+                                    .padding(.horizontal, 16)
+                                
+                                if viewModel.completions.isEmpty {
+                                    Text("You haven't completed any weekly challenge activities")
+                                        .foregroundColor(.secondary)
+                                        .frame(maxWidth: .infinity)
+                                        .padding()
+                                } else {
+                                    VStack(spacing: 8) {
+                                        ForEach(viewModel.completions.prefix(10)) { completion in
+                                            CompletionRow(completion: completion)
+                                        }
+                                    }
+                                    .padding(.horizontal, 16)
+                                }
+                            }
+                            
+                            Spacer(minLength: 80)
+                        }
+                    }
+                    .background(Color("appPrimary"))
+                }
+            }
+        }
+        .onAppear {
+            viewModel.loadCompletions(userId: userId)
+        }
+    }
+}
+
+// MARK: - Stat Card Component
+struct StatCard: View {
+    let title: String
+    let value: String
+    let icon: String
+    let color: Color
+    
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Image(systemName: icon)
+                    .font(.title2)
+                    .foregroundColor(color)
+                Spacer()
+            }
+            
+            Text(value)
+                .font(.system(size: 32, weight: .bold))
+                .foregroundColor(.primary)
+            
+            Text(title)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            
+            Spacer()
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .frame(height: 120)
+        .background(Color(.systemBackground))
+        .cornerRadius(16)
+    }
+}
+
+// MARK: - Chart View Component
+struct ChartView: View {
+    let data: [DailyCompletion]
+    
+    var body: some View {
+        Chart(data) { item in
+            BarMark(
+                x: .value("Day", item.date, unit: .day),
+                y: .value("Completed", item.count)
+            )
+            .foregroundStyle(
+                LinearGradient(
+                    colors: [.blue, .purple],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .cornerRadius(4)
+        }
+        .chartXAxis {
+            AxisMarks(values: .stride(by: .day, count: 5)) { value in
+                if let date = value.as(Date.self) {
+                    AxisValueLabel {
+                        Text(date, format: .dateTime.month(.abbreviated).day())
+                            .font(.caption2)
+                    }
+                }
+            }
+        }
+        .chartYAxis {
+            AxisMarks(position: .leading) { value in
+                AxisValueLabel {
+                    if let intValue = value.as(Int.self) {
+                        Text("\(intValue)")
+                            .font(.caption2)
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+// MARK: - Completion Row Component
+struct CompletionRow: View {
+    let completion: ActivityCompletion
+    
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, h:mm a"
+        return formatter.string(from: completion.completedAt)
+    }
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.title3)
+                .foregroundColor(.green)
+            
+            VStack(alignment: .leading, spacing: 4) {
+                Text(completion.activityName)
+                    .font(.body)
+                    .fontWeight(.medium)
+                    .foregroundColor(.primary)
+                
+                Text(formattedDate)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            Spacer()
+        }
+        .padding()
+        .background(Color(.systemBackground))
+        .cornerRadius(12)
+    }
+}
+
+// MARK: - Preview
+struct WeeklyChallengeStatsView_Previews: PreviewProvider {
+    static var previews: some View {
+        WeeklyChallengeStatsView(userId: "preview_user_123")
+    }
+}

--- a/Swifties/Views/HomeView.swift
+++ b/Swifties/Views/HomeView.swift
@@ -12,134 +12,135 @@ struct HomeView: View {
     @State private var selectedTab = 0
     
     var body: some View {
-        ZStack {
-            Color("appPrimary")
-                .ignoresSafeArea()
-            
-            VStack {
-                CustomTopBar(
-                    title: "Hi, \(getUserFirstName())!",
-                    showNotificationButton: true
-                ) {
-                    print("Notifications tapped")
-                }
+        NavigationStack { 
+            ZStack {
+                Color("appPrimary")
+                    .ignoresSafeArea()
                 
-                ScrollView {
-                    VStack (spacing: 0) {
-                        HStack {
-                            Text("What's on your mind today?")
-                                .font(.title3)
-                                .fontWeight(.semibold)
-                                .padding()
-                                .frame(minHeight: 10)
-                            
-                            Spacer()
-                        }
-                        .padding(.bottom, 10)
-                        
-                        HStack (spacing: 15) {
-                            Button {
-                                print("Weekly Challenge")
-                            } label: {
-                                Text("Weekly Challenge")
-                                    .frame(width: 120, height: 80)
-                                    .font(.body.weight(.semibold))
-                                    .foregroundStyle(.white)
+                VStack {
+                    CustomTopBar(
+                        title: "Hi, \(getUserFirstName())!",
+                        showNotificationButton: true
+                    ) {
+                        print("Notifications tapped")
+                    }
+                    
+                    ScrollView {
+                        VStack (spacing: 0) {
+                            HStack {
+                                Text("What's on your mind today?")
+                                    .font(.title3)
+                                    .fontWeight(.semibold)
+                                    .padding()
+                                    .frame(minHeight: 10)
+                                
+                                Spacer()
                             }
-                            .buttonStyle(.borderedProminent)
-                            .tint(Color("appBlue"))
+                            .padding(.bottom, 10)
                             
-                            Button {
-                                print("Personality Quiz")
-                            } label: {
-                                Text("Personality Quiz")
-                                    .frame(width: 120, height: 80)
-                                    .font(.body.weight(.semibold))
-                                    .foregroundStyle(.white)
+                            HStack (spacing: 15) {
+                                Button {
+                                    print("Weekly Challenge")
+                                } label: {
+                                    Text("Weekly Challenge")
+                                        .frame(width: 120, height: 80)
+                                        .font(.body.weight(.semibold))
+                                        .foregroundStyle(.white)
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .tint(Color("appBlue"))
+                                
+                                Button {
+                                    print("Personality Quiz")
+                                } label: {
+                                    Text("Personality Quiz")
+                                        .frame(width: 120, height: 80)
+                                        .font(.body.weight(.semibold))
+                                        .foregroundStyle(.white)
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .tint(Color("appRed"))
                             }
-                            .buttonStyle(.borderedProminent)
-                            .tint(Color("appRed"))
-                        }
-                        .padding(.bottom, 10)
-                        
-                        HStack (spacing: 15) {
-                            Button {
-                                print("Wish me Luck")
-                            } label: {
-                                Text("Wish me Luck")
-                                    .frame(width: 120, height: 80)
-                                    .font(.body.weight(.semibold))
-                                    .foregroundStyle(.white)
+                            .padding(.bottom, 10)
+                            
+                            HStack (spacing: 15) {
+                                NavigationLink { //  NavigationLink
+                                    Magic8BallView()
+                                } label: {
+                                    Text("Wish me Luck")
+                                        .frame(width: 120, height: 80)
+                                        .font(.body.weight(.semibold))
+                                        .foregroundStyle(.white)
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .tint(Color("appRed"))
+                                
+                                Button {
+                                    print("Map")
+                                } label: {
+                                    Text("Map")
+                                        .frame(width: 120, height: 80)
+                                        .font(.body.weight(.semibold))
+                                        .foregroundStyle(.white)
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .tint(Color("appBlue"))
                             }
-                            .buttonStyle(.borderedProminent)
-                            .tint(Color("appRed"))
                             
-                            Button {
-                                print("Map")
-                            } label: {
-                                Text("Map")
-                                    .frame(width: 120, height: 80)
-                                    .font(.body.weight(.semibold))
-                                    .foregroundStyle(.white)
+                            HStack {
+                                Text("Daily Recommendation")
+                                    .font(.title3)
+                                    .fontWeight(.semibold)
+                                    .padding()
+                                    .frame(minHeight: 10)
+                                
+                                Spacer()
                             }
-                            .buttonStyle(.borderedProminent)
-                            .tint(Color("appBlue"))
-                        }
-                        
-                        HStack {
-                            Text("Daily Recommendation")
-                                .font(.title3)
-                                .fontWeight(.semibold)
-                                .padding()
-                                .frame(minHeight: 10)
+                            .padding(.top, 20)
                             
-                            Spacer()
-                        }
-                        .padding(.top, 20)
-                        
-                        EventInfo(imagePath: "evento",
-                                     title: "Daily Marathon",
-                                     titleColor: Color("appOcher"),
-                                     description: "Have a blast with us on our daily marathon!",
-                                     timeText: "Today, 10am",
-                                     walkingMinutes: 8,
-                                     location: "Lleras"
-                        ).padding(.horizontal, 16)
-                        
-                        HStack {
-                            Text("Close to you")
-                                .font(.title3)
-                                .fontWeight(.semibold)
-                                .padding()
-                                .frame(minHeight: 10)
+                            EventInfo(imagePath: "evento",
+                                      title: "Daily Marathon",
+                                      titleColor: Color("appOcher"),
+                                      description: "Have a blast with us on our daily marathon!",
+                                      timeText: "Today, 10am",
+                                      walkingMinutes: 8,
+                                      location: "Lleras"
+                            ).padding(.horizontal, 16)
                             
-                            Spacer()
+                            HStack {
+                                Text("Close to you")
+                                    .font(.title3)
+                                    .fontWeight(.semibold)
+                                    .padding()
+                                    .frame(minHeight: 10)
+                                
+                                Spacer()
+                            }
+                            .padding(.top, 20)
+                            
+                            EventInfo(imagePath: "evento",
+                                      title: "Kaldivia",
+                                      titleColor: Color("appBlue"),
+                                      description: "Have a cup of coffee during your free period!",
+                                      timeText: "Today, all-day",
+                                      walkingMinutes: 6,
+                                      location: "S1")
+                            .padding(.bottom)
+                            .padding(.horizontal, 16)
+                            
+                            EventInfo(imagePath: "evento",
+                                      title: "Cívico Pets",
+                                      titleColor: Color("appOcher"),
+                                      description: "Bring your pets to the Civic Center",
+                                      timeText: "Tomorrow, 8-10am",
+                                      walkingMinutes: 4,
+                                      location: "RGD")
+                            .padding(.bottom)
+                            .padding(.horizontal, 16)
                         }
-                        .padding(.top, 20)
-                        
-                        EventInfo(imagePath: "evento",
-                                     title: "Kaldivia",
-                                     titleColor: Color("appBlue"),
-                                     description: "Have a cup of coffee during your free period!",
-                                     timeText: "Today, all-day",
-                                     walkingMinutes: 6,
-                                     location: "S1")
-                        .padding(.bottom)
-                        .padding(.horizontal, 16)
-                        EventInfo(imagePath: "evento",
-                                     title: "Cívico Pets",
-                                     titleColor: Color("appOcher"),
-                                     description: "Bring your pets to the Civic Center",
-                                     timeText: "Tomorrow, 8-10am",
-                                     walkingMinutes: 4,
-                                     location: "RGD")
-                        .padding(.bottom)
-                        .padding(.horizontal, 16)
                     }
                 }
-     
             }
-      
         }
     }
     
@@ -149,7 +150,6 @@ struct HomeView: View {
             return "User"
         }
         
-        // Extract first name from full name
         let components = displayName.components(separatedBy: " ")
         return components.first ?? displayName
     }

--- a/Swifties/Views/HomeView.swift
+++ b/Swifties/Views/HomeView.swift
@@ -139,7 +139,7 @@ struct HomeView: View {
                 }
      
             }
-            .ignoresSafeArea(.all, edges: .bottom)
+      
         }
     }
     

--- a/Swifties/Views/WishMeLuck.swift
+++ b/Swifties/Views/WishMeLuck.swift
@@ -167,7 +167,12 @@ struct Magic8BallView: View {
 
             Task { @MainActor in
                 self.events = docs.compactMap { doc -> Event? in
-                    try? doc.data(as: Event.self)
+                    do {
+                        return try doc.data(as: Event.self)
+                    } catch {
+                        print("Failed to decode Event from Firestore document \(doc.documentID): \(error)")
+                        return nil
+                    }
                 }
             }
         }

--- a/Swifties/Views/WishMeLuck.swift
+++ b/Swifties/Views/WishMeLuck.swift
@@ -1,0 +1,250 @@
+//
+//  WishMeLuck.swift
+//  Swifties
+//
+//  Created by Imac  on 2/10/25.
+//
+
+import SwiftUI
+import FirebaseFirestore
+
+struct Magic8BallView: View {
+    @State var events: [Event] = []
+    @State private var selectedEvent: Event? = nil
+    @State private var animateBall = false
+
+    var body: some View {
+        VStack {
+            Spacer().frame(height: 40)
+
+            // MARK: - Magic 8-Ball
+            ZStack {
+                Circle()
+                    .fill(Color.black)
+                    .frame(width: 280, height: 280)
+                    .shadow(color: .black.opacity(0.3), radius: 10, x: 0, y: 8)
+
+                Text("8")
+                    .font(.system(size: 130, weight: .bold))
+                    .foregroundColor(.white)
+                    .rotationEffect(.degrees(animateBall ? 360 : 0))
+                    .animation(.easeInOut(duration: 0.6), value: animateBall)
+            }
+            .padding(.top, 40)
+
+            Spacer().frame(height: 30)
+
+            // MARK: - Selected Event Info
+            VStack(spacing: 12) {
+                if let event = selectedEvent {
+
+                    // Event Image
+                    if let imageUrl = event.metadata?.imageUrl, !imageUrl.isEmpty {
+                        AsyncImage(url: URL(string: imageUrl)) { image in
+                            image
+                                .resizable()
+                                .scaledToFill()
+                        } placeholder: {
+                            Color.gray.opacity(0.3)
+                        }
+                        .frame(height: 120)
+                        .cornerRadius(16)
+                    } else {
+                        Color.gray.opacity(0.3)
+                            .frame(height: 120)
+                            .cornerRadius(16)
+                            .overlay(
+                                Image(systemName: "photo")
+                                    .font(.system(size: 40))
+                                    .foregroundColor(.white.opacity(0.7))
+                            )
+                    }
+
+                    // Event Name
+                    Text(event.name)
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .foregroundColor(.primary)
+                        .multilineTextAlignment(.center)
+
+                    // Event Description
+                    Text(event.description)
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 6)
+
+                    // Event Category and Type
+                    HStack(spacing: 16) {
+                        Label(event.category, systemImage: "tag")
+                            .font(.caption)
+                            .foregroundColor(.orange)
+
+                        Label(event.type ?? "N/A", systemImage: "star.fill")
+                            .font(.caption)
+                            .foregroundColor(.blue)
+                    }
+
+                    // Event Location, Duration, Cost
+                    HStack(spacing: 16) {
+                        Label(event.location?.address ?? "Unknown location", systemImage: "mappin.and.ellipse")
+                            .font(.caption2)
+                            .foregroundColor(.gray)
+
+                        Label("\(event.metadata?.durationMinutes ?? 0) min", systemImage: "clock")
+                            .font(.caption2)
+                            .foregroundColor(.gray)
+
+                        Label(event.metadata?.cost ?? "N/A", systemImage: "dollarsign.circle")
+                            .font(.caption2)
+                            .foregroundColor(.gray)
+                    }
+
+                    // Event Popularity and Rating
+                    HStack(spacing: 16) {
+                        Label("\(event.stats?.popularity ?? 0)% popular", systemImage: "heart.fill")
+                            .font(.caption2)
+                            .foregroundColor(.red)
+
+                        Label(String(format: "%.1f ★", event.stats?.rating ?? 0), systemImage: "star.fill")
+                            .font(.caption2)
+                            .foregroundColor(.yellow)
+                    }
+
+                } else {
+                    Text("Shake or tap the button below")
+                        .font(.body)
+                        .foregroundColor(.primary)
+
+                    Text("And let the magic 8-ball discover your perfect event!")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 280)
+            .padding(16)
+            .background(Color.white)
+            .cornerRadius(24)
+            .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 8)
+            .padding(.horizontal, 16)
+
+            Spacer().frame(height: 20)
+
+            // MARK: - Button
+            Button(action: {
+                if !events.isEmpty {
+                    withAnimation(.spring(response: 0.5, dampingFraction: 0.6)) {
+                        animateBall.toggle()
+                        selectedEvent = events.randomElement()
+                    }
+                }
+            }) {
+                Text("✨ Wish Me Luck!")
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.orange)
+                    .cornerRadius(16)
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 40)
+        }
+        .background(Color("appPrimary").ignoresSafeArea())
+        .onAppear {
+            if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" {
+                loadEventsFromFirebase()
+            }
+        }
+    }
+
+    // MARK: - Load events from Firebase
+    func loadEventsFromFirebase() {
+        let db = Firestore.firestore()
+        db.collection("events").getDocuments { snapshot, error in
+            guard let docs = snapshot?.documents else { return }
+
+            Task { @MainActor in
+                self.events = docs.compactMap { doc -> Event? in
+                    try? doc.data(as: Event.self)
+                }
+            }
+        }
+    }
+
+    // MARK: - Preview with mock events
+    struct Magic8BallView_Previews: PreviewProvider {
+        static var previews: some View {
+            let mockEvents: [Event] = [
+                Event(
+                    id: "1",
+                    title: "Rock Fest",
+                    name: "Concert",
+                    description: "Live music",
+                    type: "Concert",
+                    category: "Music",
+                    active: true,
+                    eventType: ["Music", "Concert"],
+                    location: Event.Location(
+                        city: "Bogotá",
+                        type: "Indoor",
+                        address: "Calle 123",
+                        coordinates: [4.6097, -74.0817]
+                    ),
+                    schedule: Event.Schedule(
+                        days: ["Friday", "Saturday"],
+                        times: ["18:00", "20:00"]
+                    ),
+                    metadata: Event.Metadata(
+                        imageUrl: "",
+                        tags: ["rock", "live"],
+                        durationMinutes: 120,
+                        cost: "$50"
+                    ),
+                    stats: Event.EventStats(
+                        popularity: 85,
+                        totalCompletions: 150,
+                        rating: 4.5
+                    ),
+                    weatherDependent: false,
+                    created: Timestamp(date: Date())
+                ),
+                Event(
+                    id: "2",
+                    title: "Art Expo",
+                    name: "Exhibition",
+                    description: "Modern art",
+                    type: "Exhibition",
+                    category: "Art",
+                    active: true,
+                    eventType: ["Art", "Exhibition"],
+                    location: Event.Location(
+                        city: "Bogotá",
+                        type: "Indoor",
+                        address: "Carrera 7",
+                        coordinates: [4.6533, -74.0836]
+                    ),
+                    schedule: Event.Schedule(
+                        days: ["Monday", "Tuesday"],
+                        times: ["10:00", "14:00"]
+                    ),
+                    metadata: Event.Metadata(
+                        imageUrl: "",
+                        tags: ["art", "modern"],
+                        durationMinutes: 90,
+                        cost: "Free"
+                    ),
+                    stats: Event.EventStats(
+                        popularity: 70,
+                        totalCompletions: 200,
+                        rating: 4.8
+                    ),
+                    weatherDependent: false,
+                    created: Timestamp(date: Date())
+                )
+            ]
+            Magic8BallView(events: mockEvents)
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature for tracking and displaying weekly challenge activity completion statistics, along with some navigation and UI improvements. The most significant changes are the addition of the `ActivityCompletion` model and the `WeeklyChallengeStatsView`, updates to navigation logic to support new views, and minor UI refinements.

**Feature: Weekly Challenge Statistics**

* Added `Swifties/Views/ActivityCompletion.swift` containing:
  - `ActivityCompletion` model for tracking completed activities.
  - `WeeklyChallengeStatsViewModel` for fetching and processing completion data from Firestore.
  - `WeeklyChallengeStatsView` for displaying stats, charts, and recent completions.
  - Supporting components: `StatCard`, `ChartView`, and `CompletionRow`.

**Navigation Improvements**

* Updated app entry point in `Swifties/SwiftiesApp.swift` to show `MainView` after authentication, instead of `HomeView`.
* Changed `MainView` logic in `Swifties/MainView.swift` to:
  - Default to the first tab on launch.
  - Add a new tab for `Magic8BallView`.
  - Use `HomeView` as the fallback view. 

**UI and Interaction Enhancements**

* Wrapped `HomeView` content in a `NavigationStack` to support navigation to new features.
* Updated "Wish me Luck" button in `HomeView` to use a `NavigationLink` to `Magic8BallView` for smoother navigation.

**Minor UI Adjustments**

* Improved padding and layout in `HomeView`, including spacing between event components. 
* Cleaned up name extraction logic in `HomeView` for clarity.