### PR TITLE
Recommendations initialization

### DIFF
--- a/Swifties/ViewModels/EventListViewModel.swift
+++ b/Swifties/ViewModels/EventListViewModel.swift
@@ -10,7 +10,6 @@ import FirebaseFirestore
 import Combine
 
 class EventListViewModel: ObservableObject {
-
     @Published var events: [Event] = []
     @Published var isLoading = false
     @Published var errorMessage: String?
@@ -55,7 +54,7 @@ class EventListViewModel: ObservableObject {
         }
     }
     
-    private func parseEvent(documentId: String, data: [String: Any]) -> Event? {
+    func parseEvent(documentId: String, data: [String: Any]) -> Event? {
         // Required fields
         guard let name = data["name"] as? String,
               let description = data["description"] as? String,

--- a/Swifties/ViewModels/HomeViewModel.swift
+++ b/Swifties/ViewModels/HomeViewModel.swift
@@ -37,7 +37,7 @@ final class HomeViewModel: ObservableObject {
                 recommendations.append(event)
             } else {
                 print("No valid data for document \(eventID)")
-                return []
+                continue
             }
         }
         

--- a/Swifties/ViewModels/HomeViewModel.swift
+++ b/Swifties/ViewModels/HomeViewModel.swift
@@ -1,0 +1,47 @@
+//
+//  HomeViewModel.swift
+//  Swifties
+//
+//  Created by Juan Esteban Vasquez Parra on 4/10/25.
+//
+
+import FirebaseAuth
+import FirebaseFirestore
+import Combine
+
+@MainActor
+final class HomeViewModel: ObservableObject {
+    let firestore = Firestore.firestore(database: "default")
+    let eventListViewModel = EventListViewModel()
+    @Published var recommendations: [Event] = []
+    
+    init() {
+        // Initialize Firestore and configure settings
+        let firestore = Firestore.firestore()
+        let settings = FirestoreSettings()
+        //settings.isPersistenceEnabled = true // optional offline cache
+        firestore.settings = settings
+    }
+    
+    func getRecommendations() async throws -> [Event] {
+        // let userID = Auth.auth().currentUser?.uid
+        let searchResults: [String] = ["19ph2WwBuiuI0Rgw7t5F",
+                                       "1XrXxsVrJWnFCsmDJ3YH",
+                                       "6avFMINUtpniHV2EIl6m",
+                                       "LX7WvPRQrAgPQ40GEhOy",
+                                       "SdmE00SDRbcclnQ0lvlf"] // TODO: Add functionality of the model via REST or FAST API
+                
+        for eventID in searchResults {
+            let document = try await firestore.collection("events").document(eventID).getDocument()
+            if let data = document.data(),
+                let event = eventListViewModel.parseEvent(documentId: eventID, data: data) {
+                recommendations.append(event)
+            } else {
+                print("No valid data for document \(eventID)")
+                return []
+            }
+        }
+        
+        return recommendations
+    }
+}

--- a/Swifties/ViewModels/HomeViewModel.swift
+++ b/Swifties/ViewModels/HomeViewModel.swift
@@ -17,10 +17,9 @@ final class HomeViewModel: ObservableObject {
     
     init() {
         // Initialize Firestore and configure settings
-        let firestore = Firestore.firestore()
         let settings = FirestoreSettings()
         //settings.isPersistenceEnabled = true // optional offline cache
-        firestore.settings = settings
+        self.firestore.settings = settings
     }
     
     func getRecommendations() async throws -> [Event] {

--- a/Swifties/Views/HomeView.swift
+++ b/Swifties/Views/HomeView.swift
@@ -146,16 +146,6 @@ struct HomeView: View {
                             .padding(.top, 20)
                             
                             EventInfo(imagePath: "evento",
-                                      title: "Kaldivia",
-                                      titleColor: Color("appBlue"),
-                                      description: "Have a cup of coffee during your free period!",
-                                      timeText: "Today, all-day",
-                                      walkingMinutes: 6,
-                                      location: "S1")
-                            .padding(.bottom)
-                            .padding(.horizontal, 16)
-                            
-                            EventInfo(imagePath: "evento",
                                       title: "Cívico Pets",
                                       titleColor: Color("appOcher"),
                                       description: "Bring your pets to the Civic Center",

--- a/Swifties/Views/HomeView.swift
+++ b/Swifties/Views/HomeView.swift
@@ -11,6 +11,9 @@ struct HomeView: View {
     @EnvironmentObject var viewModel: AuthViewModel
     @State private var selectedTab = 0
     
+    @StateObject var homeViewModel = HomeViewModel()
+    @State private var recommended: [Event]  = []
+        
     var body: some View {
         NavigationStack { 
             ZStack {
@@ -94,6 +97,33 @@ struct HomeView: View {
                                 Spacer()
                             }
                             .padding(.top, 20)
+                            
+                            VStack(spacing: 12) {
+                                if recommended.isEmpty {
+                                    ProgressView("Loading recommendations…")
+                                } else {
+                                    ForEach(recommended) { event in
+                                        NavigationLink(destination: EventDetailView(event: event)) {
+                                            EventInfo(
+                                                imagePath: event.metadata.imageUrl,
+                                                title: event.name,
+                                                titleColor: Color.orange,
+                                                description: event.description,
+                                                timeText: event.schedule.times.first ?? "Time TBD",
+                                                walkingMinutes: 5,
+                                                location: event.location?.address
+                                            )
+                                        }
+                                }
+                                .padding(.horizontal, 16)}
+                            }
+                            .task {
+                                do {
+                                    recommended = try await homeViewModel.getRecommendations()
+                                } catch {
+                                    print("Error loading recommendations: \(error)")
+                                }
+                            }
                             
                             EventInfo(imagePath: "evento",
                                       title: "Daily Marathon",


### PR DESCRIPTION
This pull request introduces a new recommendations feature to the home screen, leveraging a new `HomeViewModel` to fetch and display personalized event recommendations. The changes also refactor some code to support this integration and improve testability.

**Feature: Event Recommendations on Home Screen**
* Added a new `HomeViewModel` (`Swifties/ViewModels/HomeViewModel.swift`) that fetches recommended events asynchronously from Firestore and parses them using `EventListViewModel`.
* Updated `HomeView` (`Swifties/Views/HomeView.swift`) to use `HomeViewModel`, display a loading indicator while recommendations are loading, and show recommended events as a list of `EventInfo` cards with navigation to event details. [[1]](diffhunk://#diff-aceae07ac16be25a94ba3f8fbd627ed2f3f15f53258e6fefdd04f75c4efe0f0eR14-R16) [[2]](diffhunk://#diff-aceae07ac16be25a94ba3f8fbd627ed2f3f15f53258e6fefdd04f75c4efe0f0eR101-R127)

**Codebase Improvements and Refactoring**
* Changed `parseEvent` in `EventListViewModel` from private to internal, allowing `HomeViewModel` to reuse the event parsing logic.
* Removed a hardcoded example event from `HomeView` to make space for the dynamic recommendations section.

**Minor Cleanup**
* Minor whitespace adjustment in `EventListViewModel` for clarity.