### PR TITLE
fix the Wish Me Luck feature button

### DIFF
--- a/Swifties/ViewModels/WishMeLuckViewModel.swift
+++ b/Swifties/ViewModels/WishMeLuckViewModel.swift
@@ -35,7 +35,6 @@ class WishMeLuckViewModel: ObservableObject {
     }
     
     // MARK: - Wish Me Luck
-    // MARK: - Wish Me Luck
     func wishMeLuck() async {
         isLoading = true
         error = nil

--- a/Swifties/ViewModels/WishMeLuckViewModel.swift
+++ b/Swifties/ViewModels/WishMeLuckViewModel.swift
@@ -70,7 +70,7 @@ class WishMeLuckViewModel: ObservableObject {
                     )
                 }
             } else {
-                print("No hay documentos con activetrue = true")
+                print("No hay documentos con active = true")
                 currentEvent = nil
             }
 

--- a/Swifties/ViewModels/WishMeLuckViewModel.swift
+++ b/Swifties/ViewModels/WishMeLuckViewModel.swift
@@ -78,7 +78,7 @@ class WishMeLuckViewModel: ObservableObject {
             await calculateDaysSinceLastWished()
         } catch {
             self.error = "Error getting event: \(error.localizedDescription)"
-            print("rror Firestore: \(error)")
+            print("Error Firestore: \(error)")
         }
 
         isLoading = false


### PR DESCRIPTION
This pull request refactors the handling and decoding of event data for the "Wish Me Luck" feature, improving robustness when working with varied Firestore data structures and streamlining the event-fetching logic. The most important changes focus on making the model more resilient to different field naming conventions, simplifying the view model logic, and enhancing error handling.

**Model decoding improvements:**

* The `WishMeLuckEvent` struct now supports decoding `imageUrl` from both snake_case and camelCase fields, and also from nested `metadata` objects, making it more robust to inconsistencies in Firestore data. 
* Default values are provided for missing fields (`id`, `title`, `description`) to prevent crashes and ensure graceful handling of incomplete event data.

**ViewModel logic simplification:**

* The `wishMeLuck` method in `WishMeLuckViewModel` was refactored to fetch and parse events directly, removing the separate `getRandomEvent` method and handling both standard and fallback parsing in one place.
* Error handling and logging were improved in the event-fetching logic, providing more informative console output for debugging Firestore issues.

**Code organization and clarity:**

* Added clear `MARK` comments to separate logical sections in both the model and view model, improving code readability. 