### PR TITLE
Refactor Event Parsing with Centralized EventFactory and Update Navigation

### DIFF
--- a/Swifties/Components/Factories/EventFactory.swift
+++ b/Swifties/Components/Factories/EventFactory.swift
@@ -8,7 +8,7 @@ class EventFactory {
         return parseEventData(data)
     }
     
-    // ✅ NUEVO: Método para DocumentSnapshot (usado en getDocument)
+    // NEW: Method for DocumentSnapshot (used in getDocument)
     static func createEvent(from document: DocumentSnapshot) -> Event? {
         guard let data = document.data() else { return nil }
         return parseEventData(data)

--- a/Swifties/Components/Factories/EventFactory.swift
+++ b/Swifties/Components/Factories/EventFactory.swift
@@ -1,0 +1,96 @@
+// EventFactory.swift
+import FirebaseFirestore
+
+class EventFactory {
+    // Método original para QueryDocumentSnapshot (usado en queries)
+    static func createEvent(from document: QueryDocumentSnapshot) -> Event? {
+        let data = document.data()
+        return parseEventData(data)
+    }
+    
+    // ✅ NUEVO: Método para DocumentSnapshot (usado en getDocument)
+    static func createEvent(from document: DocumentSnapshot) -> Event? {
+        guard let data = document.data() else { return nil }
+        return parseEventData(data)
+    }
+    
+    // Método privado compartido que hace el parsing real
+    private static func parseEventData(_ data: [String: Any]) -> Event? {
+        guard let name = data["name"] as? String,
+              let description = data["description"] as? String,
+              let category = data["category"] as? String else {
+            return nil
+        }
+        
+        let location = parseLocation(from: data["location"] as? [String: Any])
+        let schedule = parseSchedule(from: data["schedule"] as? [String: Any])
+        let metadata = parseMetadata(from: data["metadata"] as? [String: Any])
+        let stats = parseStats(from: data["stats"] as? [String: Any])
+        
+        return Event(
+            activetrue: data["activetrue"] as? Bool ?? true,
+            category: category,
+            created: data["created"] as? String ?? "",
+            description: description,
+            eventType: data["event_type"] as? String ?? "",
+            location: location,
+            metadata: metadata,
+            name: name,
+            schedule: schedule,
+            stats: stats,
+            title: data["title"] as? String ?? "",
+            type: data["type"] as? String ?? "",
+            weatherDependent: data["weather_dependent"] as? Bool ?? false
+        )
+    }
+    
+    private static func parseLocation(from data: [String: Any]?) -> EventLocation {
+        guard let data = data else { return EventLocation(address: "", city: "", coordinates: [], type: "") }
+        return EventLocation(
+            address: data["address"] as? String ?? "",
+            city: data["city"] as? String ?? "",
+            coordinates: data["coordinates"] as? [Double] ?? [],
+            type: data["type"] as? String ?? ""
+        )
+    }
+    
+    private static func parseSchedule(from data: [String: Any]?) -> EventSchedule {
+        guard let data = data else { return EventSchedule(days: [], times: []) }
+        return EventSchedule(
+            days: data["days"] as? [String] ?? [],
+            times: data["times"] as? [String] ?? []
+        )
+    }
+    
+    private static func parseMetadata(from data: [String: Any]?) -> EventMetadata {
+        guard let data = data else {
+            return EventMetadata(cost: EventCost(amount: 0, currency: "COP"), durationMinutes: 0, imageUrl: "", tags: [])
+        }
+        
+        let cost: EventCost
+        if let costData = data["cost"] as? [String: Any] {
+            cost = EventCost(
+                amount: costData["amount"] as? Int ?? 0,
+                currency: costData["currency"] as? String ?? "COP"
+            )
+        } else {
+            cost = EventCost(amount: 0, currency: "COP")
+        }
+        
+        return EventMetadata(
+            cost: cost,
+            durationMinutes: data["duration_minutes"] as? Int ?? 0,
+            imageUrl: data["image_url"] as? String ?? "",
+            tags: data["tags"] as? [String] ?? []
+        )
+    }
+    
+    private static func parseStats(from data: [String: Any]?) -> EventStats {
+        guard let data = data else { return EventStats(popularity: 0, rating: 0, totalCompletions: 0) }
+        return EventStats(
+            popularity: data["popularity"] as? Int ?? 0,
+            rating: data["rating"] as? Int ?? 0,
+            totalCompletions: data["total_completions"] as? Int ?? 0
+        )
+    }
+}

--- a/Swifties/ViewModels/EventListViewModel.swift
+++ b/Swifties/ViewModels/EventListViewModel.swift
@@ -44,94 +44,15 @@ class EventListViewModel: ObservableObject {
                     return
                 }
 
-                // Parse documents with complete data
-                self.events = documents.compactMap { doc in
-                    self.parseEvent(documentId: doc.documentID, data: doc.data())
-                }
+                
+                self.events = documents.compactMap { EventFactory.createEvent(from: $0) }
 
                 print("Events loaded: \(self.events.count)")
             }
         }
     }
     
-    func parseEvent(documentId: String, data: [String: Any]) -> Event? {
-        // Required fields
-        guard let name = data["name"] as? String,
-              let description = data["description"] as? String,
-              let category = data["category"] as? String else {
-            print("Incomplete document: \(documentId)")
-            return nil
-        }
-        
-        // Location parsing
-        var location = EventLocation(address: "", city: "", coordinates: [], type: "")
-        if let locationData = data["location"] as? [String: Any] {
-            location = EventLocation(
-                address: locationData["address"] as? String ?? "",
-                city: locationData["city"] as? String ?? "",
-                coordinates: locationData["coordinates"] as? [Double] ?? [],
-                type: locationData["type"] as? String ?? ""
-            )
-        }
-        
-        // Schedule parsing
-        var schedule = EventSchedule(days: [], times: [])
-        if let scheduleData = data["schedule"] as? [String: Any] {
-            schedule = EventSchedule(
-                days: scheduleData["days"] as? [String] ?? [],
-                times: scheduleData["times"] as? [String] ?? []
-            )
-        }
-        
-        // Metadata parsing
-        var metadata = EventMetadata(
-            cost: EventCost(amount: 0, currency: "COP"),
-            durationMinutes: 0,
-            imageUrl: "",
-            tags: []
-        )
-        if let metadataData = data["metadata"] as? [String: Any] {
-            var cost = EventCost(amount: 0, currency: "COP")
-            if let costData = metadataData["cost"] as? [String: Any] {
-                let amount = costData["amount"] as? Int ?? 0
-                let currency = costData["currency"] as? String ?? "COP"
-                cost = EventCost(amount: amount, currency: currency)
-            }
-            
-            metadata = EventMetadata(
-                cost: cost,
-                durationMinutes: metadataData["duration_minutes"] as? Int ?? 0,
-                imageUrl: metadataData["image_url"] as? String ?? "",
-                tags: metadataData["tags"] as? [String] ?? []
-            )
-        }
-        
-        // Stats parsing
-        var stats = EventStats(popularity: 0, rating: 0, totalCompletions: 0)
-        if let statsData = data["stats"] as? [String: Any] {
-            stats = EventStats(
-                popularity: statsData["popularity"] as? Int ?? 0,
-                rating: statsData["rating"] as? Int ?? 0,
-                totalCompletions: statsData["total_completions"] as? Int ?? 0
-            )
-        }
-        
-        return Event(
-            activetrue: data["activetrue"] as? Bool ?? true,
-            category: category,
-            created: data["created"] as? String ?? "",
-            description: description,
-            eventType: data["event_type"] as? String ?? "",
-            location: location,
-            metadata: metadata,
-            name: name,
-            schedule: schedule,
-            stats: stats,
-            title: data["title"] as? String ?? "",
-            type: data["type"] as? String ?? "",
-            weatherDependent: data["weather_dependent"] as? Bool ?? false
-        )
-    }
+
     
     private func formatNumber(_ number: Int) -> String {
         let formatter = NumberFormatter()

--- a/Swifties/ViewModels/HomeViewModel.swift
+++ b/Swifties/ViewModels/HomeViewModel.swift
@@ -54,7 +54,7 @@ final class HomeViewModel: ObservableObject {
     func getAllEvents() async throws -> [Event] {
         let snapshot = try await db.collection("events").getDocuments()
         
-        // ✅ USA EventFactory directamente
+        // ✅ Use EventFactory directly
         let events: [Event] = snapshot.documents.compactMap { doc in
             EventFactory.createEvent(from: doc)
         }

--- a/Swifties/ViewModels/HomeViewModel.swift
+++ b/Swifties/ViewModels/HomeViewModel.swift
@@ -12,7 +12,8 @@ import Combine
 @MainActor
 final class HomeViewModel: ObservableObject {
     let db = Firestore.firestore(database: "default")
-    let eventListViewModel = EventListViewModel()
+    // ❌ Ya no necesitas esta línea - EventListViewModel ya no tiene parseEvent
+    // let eventListViewModel = EventListViewModel()
     @Published var recommendations: [Event] = []
     
     init() {
@@ -36,8 +37,9 @@ final class HomeViewModel: ObservableObject {
         
         for eventID in searchResults {
             let document = try await db.collection("events").document(eventID).getDocument()
-            if let data = document.data(),
-               let event = eventListViewModel.parseEvent(documentId: eventID, data: data) {
+            
+          
+            if let event = EventFactory.createEvent(from: document) {
                 recommendations.append(event)
             } else {
                 print("No valid data for document \(eventID)")
@@ -51,10 +53,12 @@ final class HomeViewModel: ObservableObject {
     // Fetch all events for map and other listings
     func getAllEvents() async throws -> [Event] {
         let snapshot = try await db.collection("events").getDocuments()
+        
+        // ✅ USA EventFactory directamente
         let events: [Event] = snapshot.documents.compactMap { doc in
-            eventListViewModel.parseEvent(documentId: doc.documentID, data: doc.data())
+            EventFactory.createEvent(from: doc)
         }
+        
         return events
     }
 }
-

--- a/Swifties/ViewModels/UserInfoViewModel.swift
+++ b/Swifties/ViewModels/UserInfoViewModel.swift
@@ -94,6 +94,7 @@ class UserInfoViewModel: ObservableObject {
     }
     
     // MARK: - Fetch Events
+    
     private func fetchEvents(completion: @escaping (Result<[Event], Error>) -> Void) {
         db.collection("events").getDocuments { snapshot, error in
             if let error = error {
@@ -106,88 +107,14 @@ class UserInfoViewModel: ObservableObject {
                 return
             }
             
-            let events = documents.compactMap { doc -> Event? in
-                self.parseEvent(documentId: doc.documentID, data: doc.data())
-            }
+          
+            let events = documents.compactMap { EventFactory.createEvent(from: $0) }
             
             completion(.success(events))
         }
     }
     
-    // MARK: - Parse Event
-    private func parseEvent(documentId: String, data: [String: Any]) -> Event? {
-        guard let name = data["name"] as? String,
-              let description = data["description"] as? String,
-              let category = data["category"] as? String else {
-            return nil
-        }
-        
-        var location = EventLocation(address: "", city: "", coordinates: [], type: "")
-        if let locationData = data["location"] as? [String: Any] {
-            location = EventLocation(
-                address: locationData["address"] as? String ?? "",
-                city: locationData["city"] as? String ?? "",
-                coordinates: locationData["coordinates"] as? [Double] ?? [],
-                type: locationData["type"] as? String ?? ""
-            )
-        }
-        
-        var schedule = EventSchedule(days: [], times: [])
-        if let scheduleData = data["schedule"] as? [String: Any] {
-            schedule = EventSchedule(
-                days: scheduleData["days"] as? [String] ?? [],
-                times: scheduleData["times"] as? [String] ?? []
-            )
-        }
-        
-        var metadata = EventMetadata(
-            cost: EventCost(amount: 0, currency: "COP"),
-            durationMinutes: 0,
-            imageUrl: "",
-            tags: []
-        )
-        if let metadataData = data["metadata"] as? [String: Any] {
-            var cost = EventCost(amount: 0, currency: "COP")
-            if let costData = metadataData["cost"] as? [String: Any] {
-                cost = EventCost(
-                    amount: costData["amount"] as? Int ?? 0,
-                    currency: costData["currency"] as? String ?? "COP"
-                )
-            }
-            
-            metadata = EventMetadata(
-                cost: cost,
-                durationMinutes: metadataData["duration_minutes"] as? Int ?? 0,
-                imageUrl: metadataData["image_url"] as? String ?? "",
-                tags: metadataData["tags"] as? [String] ?? []
-            )
-        }
-        
-        var stats = EventStats(popularity: 0, rating: 0, totalCompletions: 0)
-        if let statsData = data["stats"] as? [String: Any] {
-            stats = EventStats(
-                popularity: statsData["popularity"] as? Int ?? 0,
-                rating: statsData["rating"] as? Int ?? 0,
-                totalCompletions: statsData["total_completions"] as? Int ?? 0
-            )
-        }
-        
-        return Event(
-            activetrue: data["activetrue"] as? Bool ?? true,
-            category: category,
-            created: data["created"] as? String ?? "",
-            description: description,
-            eventType: data["event_type"] as? String ?? "",
-            location: location,
-            metadata: metadata,
-            name: name,
-            schedule: schedule,
-            stats: stats,
-            title: data["title"] as? String ?? "",
-            type: data["type"] as? String ?? "",
-            weatherDependent: data["weather_dependent"] as? Bool ?? false
-        )
-    }
+
     
     // MARK: - Filter Available Events
     private func filterAvailableEvents() {

--- a/Swifties/ViewModels/WeeklyChallengeViewModel.swift
+++ b/Swifties/ViewModels/WeeklyChallengeViewModel.swift
@@ -315,7 +315,7 @@ class WeeklyChallengeViewModel: ObservableObject {
             let index = seed % documents.count
             let selectedDoc = documents[index]
             
-            // 🎯 AQUÍ USAMOS EL FACTORY - Reemplaza las 80+ líneas de parseEvent
+            // 🎯 HERE WE USE THE FACTORY - Replaces the 80+ lines of parseEvent
             if let event = EventFactory.createEvent(from: selectedDoc) {
                 completion(.success(event))
             } else {

--- a/Swifties/ViewModels/WeeklyChallengeViewModel.swift
+++ b/Swifties/ViewModels/WeeklyChallengeViewModel.swift
@@ -291,6 +291,7 @@ class WeeklyChallengeViewModel: ObservableObject {
             }
     }
     
+    // ✅ CAMBIO PRINCIPAL: Esta función ahora usa EventFactory
     private func loadRandomEvent(completion: @escaping (Result<Event, Error>) -> Void) {
         var calendar = Calendar.current
         calendar.firstWeekday = 2
@@ -314,7 +315,8 @@ class WeeklyChallengeViewModel: ObservableObject {
             let index = seed % documents.count
             let selectedDoc = documents[index]
             
-            if let event = self.parseEvent(documentId: selectedDoc.documentID, data: selectedDoc.data()) {
+            // 🎯 AQUÍ USAMOS EL FACTORY - Reemplaza las 80+ líneas de parseEvent
+            if let event = EventFactory.createEvent(from: selectedDoc) {
                 completion(.success(event))
             } else {
                 let error = NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to parse event"])
@@ -338,78 +340,5 @@ class WeeklyChallengeViewModel: ObservableObject {
         }
     }
     
-    private func parseEvent(documentId: String, data: [String: Any]) -> Event? {
-        guard let name = data["name"] as? String,
-              let description = data["description"] as? String,
-              let category = data["category"] as? String else {
-            return nil
-        }
-        
-        var location = EventLocation(address: "", city: "", coordinates: [], type: "")
-        if let locationData = data["location"] as? [String: Any] {
-            location = EventLocation(
-                address: locationData["address"] as? String ?? "",
-                city: locationData["city"] as? String ?? "",
-                coordinates: locationData["coordinates"] as? [Double] ?? [],
-                type: locationData["type"] as? String ?? ""
-            )
-        }
-        
-        var schedule = EventSchedule(days: [], times: [])
-        if let scheduleData = data["schedule"] as? [String: Any] {
-            schedule = EventSchedule(
-                days: scheduleData["days"] as? [String] ?? [],
-                times: scheduleData["times"] as? [String] ?? []
-            )
-        }
-        
-        var metadata = EventMetadata(
-            cost: EventCost(amount: 0, currency: "COP"),
-            durationMinutes: 0,
-            imageUrl: "",
-            tags: []
-        )
-        if let metadataData = data["metadata"] as? [String: Any] {
-            var cost = EventCost(amount: 0, currency: "COP")
-            if let costData = metadataData["cost"] as? [String: Any] {
-                cost = EventCost(
-                    amount: costData["amount"] as? Int ?? 0,
-                    currency: costData["currency"] as? String ?? "COP"
-                )
-            }
-            
-            metadata = EventMetadata(
-                cost: cost,
-                durationMinutes: metadataData["duration_minutes"] as? Int ?? 0,
-                imageUrl: metadataData["image_url"] as? String ?? "",
-                tags: metadataData["tags"] as? [String] ?? []
-            )
-        }
-        
-        var stats = EventStats(popularity: 0, rating: 0, totalCompletions: 0)
-        if let statsData = data["stats"] as? [String: Any] {
-            stats = EventStats(
-                popularity: statsData["popularity"] as? Int ?? 0,
-                rating: statsData["rating"] as? Int ?? 0,
-                totalCompletions: statsData["total_completions"] as? Int ?? 0
-            )
-        }
-        
-        return Event(
-            activetrue: data["activetrue"] as? Bool ?? true,
-            category: category,
-            created: data["created"] as? String ?? "",
-            description: description,
-            eventType: data["event_type"] as? String ?? "",
-            location: location,
-            metadata: metadata,
-            name: name,
-            schedule: schedule,
-            stats: stats,
-            title: data["title"] as? String ?? "",
-            type: data["type"] as? String ?? "",
-            weatherDependent: data["weather_dependent"] as? Bool ?? false
-        )
-    }
+
 }
- 

--- a/Swifties/Views/HomeView.swift
+++ b/Swifties/Views/HomeView.swift
@@ -62,9 +62,9 @@ struct HomeView: View {
                             
                             HStack (spacing: 15) {
                                 Button(action: {
-                                    // No hacer nada
+                              
                                 }) {
-                                    Text("Wish me Luck")
+                                    Text("Place Holder")
                                         .frame(width: 120, height: 80)
                                         .font(.body.weight(.semibold))
                                         .foregroundStyle(.white)

--- a/Swifties/Views/HomeView.swift
+++ b/Swifties/Views/HomeView.swift
@@ -61,9 +61,9 @@ struct HomeView: View {
                             .padding(.bottom, 10)
                             
                             HStack (spacing: 15) {
-                                NavigationLink { //  NavigationLink
-                                    WishMeLuckView()
-                                } label: {
+                                Button(action: {
+                                    // No hacer nada
+                                }) {
                                     Text("Wish me Luck")
                                         .frame(width: 120, height: 80)
                                         .font(.body.weight(.semibold))
@@ -71,6 +71,7 @@ struct HomeView: View {
                                 }
                                 .buttonStyle(.borderedProminent)
                                 .tint(Color("appRed"))
+
                                 
                                 Button {
                                     print("Map")

--- a/Swifties/Views/LoginView.swift
+++ b/Swifties/Views/LoginView.swift
@@ -47,7 +47,7 @@ struct LoginView: View {
                             VerifyEmailView()
                                 .environmentObject(viewModel)
                         } else {
-                            HomeView()
+                            MainView()
                                 .environmentObject(viewModel)
                                 .navigationBarBackButtonHidden(true)
                         }

--- a/Swifties/Views/StartView.swift
+++ b/Swifties/Views/StartView.swift
@@ -63,18 +63,7 @@ struct StartView: View {
                 }
                 
                 Spacer()
-                Button {
-                    Task {
-                        await authViewModel.logout()
-                    }
-                } label: {
-                    Text("Logout")
-                        .frame(width: 120, height: 45)
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(.black)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(Color("appSecondary"))
+
             
             }
         }


### PR DESCRIPTION
This pull request refactors the way event data is parsed throughout the codebase by introducing a centralized `EventFactory` class. The change eliminates duplicated event parsing logic from several view models and updates all usages to rely on the new factory. Additionally, there are minor UI updates and navigation changes in the views.

**Event parsing refactor:**

* Added the new `EventFactory` class (`Swifties/Components/Factories/EventFactory.swift`) to centralize and standardize event parsing from Firestore documents, supporting both `QueryDocumentSnapshot` and `DocumentSnapshot`.
* Removed custom `parseEvent` methods from `EventListViewModel`, `UserInfoViewModel`, and `WeeklyChallengeViewModel`, updating all event fetching logic to use `EventFactory.createEvent`.
**UI and navigation changes:**

* Replaced the "Wish Me Luck" navigation link in `HomeView` with a placeholder button.
* Changed the post-login navigation from `HomeView` to `MainView` in `LoginView`.
* Removed the logout button from `StartView`.