### PR TITLE
Changes to make it work

### DIFF
--- a/Swifties.xcodeproj/project.pbxproj
+++ b/Swifties.xcodeproj/project.pbxproj
@@ -437,7 +437,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = WGPSL5WBS8;
+				DEVELOPMENT_TEAM = Y2RSVM78BU;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -446,6 +446,9 @@
 				INFOPLIST_FILE = Swifties/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Parchandes;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
+				INFOPLIST_KEY_NSCameraUsageDescription = "The camera is used to upload photos directly when making a comment";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "When location is active, the app will be able to show you a map view and the closest activities to you; including those in a 1km radius.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "The photo library is accessed in case you want to upload a photo to a comment you make";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -462,7 +465,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = moviles202520.Swifties;
+				PRODUCT_BUNDLE_IDENTIFIER = com.villegas;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -490,7 +493,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = WGPSL5WBS8;
+				DEVELOPMENT_TEAM = Y2RSVM78BU;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -499,6 +502,9 @@
 				INFOPLIST_FILE = Swifties/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Parchandes;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
+				INFOPLIST_KEY_NSCameraUsageDescription = "The camera is used to upload photos directly when making a comment";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "When location is active, the app will be able to show you a map view and the closest activities to you; including those in a 1km radius.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "The photo library is accessed in case you want to upload a photo to a comment you make";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -515,7 +521,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = moviles202520.Swifties;
+				PRODUCT_BUNDLE_IDENTIFIER = com.villegas;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;

--- a/Swifties/Info.plist
+++ b/Swifties/Info.plist
@@ -2,12 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>The photo library is accessed in case you want to upload a photo to a comment you make</string>
-	<key>NSCameraUsageDescription</key>
-	<string>The camera is used to upload photos directly when making a comment</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>When location is active, the app will be able to show you a map view and the closest activities to you; including those in a 1km radius.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Swifties/ViewModels/HomeViewModel.swift
+++ b/Swifties/ViewModels/HomeViewModel.swift
@@ -89,20 +89,22 @@ final class HomeViewModel: ObservableObject {
     // MARK: - Load Events from Firestore
     private func loadRecommendations(from eventIDs: [String]) async {
         var tempEvents: [Event] = []
-        
-        for eventID in searchResults {
-            let document = try await db.collection("events").document(eventID).getDocument()
-            
-          
-            if let event = EventFactory.createEvent(from: document) {
-                recommendations.append(event)
-            } else {
-                print("No valid data for document \(eventID)")
-                continue
+
+        for eventID in eventIDs {
+            do {
+                let document = try await db.collection("events").document(eventID).getDocument()
+
+                if let event = EventFactory.createEvent(from: document) {
+                    tempEvents.append(event)
+                } else {
+                    print("No valid data for document \(eventID)")
+                }
+            } catch {
+                print("Failed to fetch document \(eventID): \(error.localizedDescription)")
+                 continue
             }
         }
-        
-        // Update published property on main thread
+        // Update published property
         recommendations = tempEvents
     }
     


### PR DESCRIPTION
This pull request primarily updates project configuration settings and improves error handling in the recommendations loading logic. The most significant changes include updating the development team and bundle identifier in the project settings, handling errors while fetching event recommendations, and moving privacy usage descriptions from the `Info.plist` file to the project configuration.

**Project configuration updates:**

* Changed the `DEVELOPMENT_TEAM` value in `Swifties.xcodeproj/project.pbxproj` to `Y2RSVM78BU` for both iOS and macOS targets. 
**Privacy and permissions management:**

* Added privacy usage descriptions for camera, location, and photo library to the project configuration (`Swifties.xcodeproj/project.pbxproj`), and removed these keys from `Swifties/Info.plist` to centralize permission messaging. 
**Code improvements:**

* Improved error handling in the `loadRecommendations(from:)` method of `HomeViewModel` by wrapping document fetches in a `do-catch` block and logging errors, ensuring the recommendations list is only updated with valid events.