### PR TITLE
Email authentication fixes

### DIFF
--- a/Swifties/Components/Profile/ProfileHeader.swift
+++ b/Swifties/Components/Profile/ProfileHeader.swift
@@ -142,7 +142,7 @@ struct ProfileHeader: View {
             // Save reference path to Firestore under profile.photo as a String containing the storage path
             let db = Firestore.firestore(database: "default")
             let userRef = db.collection("users").document(uid)
-            try await userRef.setData(["profile": ["photo": url]], merge: true)
+            try await userRef.setData(["profile": ["photo": url.absoluteString]], merge: true)
         } catch {
             print("Failed to upload or save photo: \(error)")
         }

--- a/Swifties/Models/UserModel.swift
+++ b/Swifties/Models/UserModel.swift
@@ -31,7 +31,7 @@ struct Profile: Codable {
         case name
         case email
         case gender
-        case avatarURL = "avatar_url"
+        case avatarURL = "photo"
         case created
         case lastActive = "last_active"
         case age

--- a/Swifties/SwiftiesApp.swift
+++ b/Swifties/SwiftiesApp.swift
@@ -47,12 +47,19 @@ struct SwiftiesApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack {
-                if authViewModel.isAuthenticated && authViewModel.user != nil {
-                    let needsEmailVerification = (authViewModel.user?.providerId == "password") && (authViewModel.isEmailVerified == false)
+                if authViewModel.isAuthenticated, authViewModel.user != nil {
+                    let isEmailProvider = (authViewModel.user?.providerId == "password")
+                    let needsEmailVerification = isEmailProvider && (authViewModel.isEmailVerified == false)
+
                     if needsEmailVerification {
                         VerifyEmailView()
                             .environmentObject(authViewModel)
+                    } else if authViewModel.isFirstTimeUser {
+                        // New or incomplete users go to onboarding/interview
+                        RegisterView()
+                            .environmentObject(authViewModel)
                     } else {
+                        // Returning users go to the main app
                         MainView()
                             .environmentObject(authViewModel)
                     }

--- a/Swifties/ViewModels/AuthViewModel.swift
+++ b/Swifties/ViewModels/AuthViewModel.swift
@@ -18,6 +18,7 @@ class AuthViewModel: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var error: String?
     @Published var isFirstTimeUser: Bool = false
+    @Published var isEmailVerified: Bool = false
     
     // AuthService singleton
     private let authService = AuthService.shared
@@ -227,10 +228,7 @@ class AuthViewModel: ObservableObject {
         } catch {
             print("Error reloading user: \(error.localizedDescription)")
         }
-    }
-
-    var isEmailVerified: Bool {
-        return Auth.auth().currentUser?.isEmailVerified ?? false
+        isEmailVerified = Auth.auth().currentUser?.isEmailVerified ?? false
     }
 
     // MARK: - Logout

--- a/Swifties/Views/LoginView.swift
+++ b/Swifties/Views/LoginView.swift
@@ -42,6 +42,9 @@ struct LoginView: View {
                     handleRedirect()
                 }
             }
+            .onChange(of: viewModel.isEmailVerified) {
+                handleRedirect()
+            }
             .navigationDestination(isPresented: $shouldNavigate) {
                 if let destination = navigationDestination {
                     switch destination {

--- a/Swifties/Views/ProfileView.swift
+++ b/Swifties/Views/ProfileView.swift
@@ -40,6 +40,18 @@ struct ProfileView: View {
                                     viewModel.loadProfile()
                                 }
                                 .buttonStyle(.borderedProminent)
+                                
+                                Spacer()
+                                
+                                ActionButton(
+                                    title: "Delete your account",
+                                    backgroundColor: Color("appRed")
+                                ) {
+                                    // Handle account deletion
+                                    Task {
+                                        await authViewModel.deleteAccount()
+                                    }
+                                }
                             }
                             .padding(.top, 40)
                         } else if let profile = viewModel.profile {

--- a/Swifties/Views/VerifyEmailView.swift
+++ b/Swifties/Views/VerifyEmailView.swift
@@ -17,43 +17,38 @@ struct VerifyEmailView: View {
                 .ignoresSafeArea()
             
             VStack(spacing: 20) {
-                Text("Please verify your email from the link sent to your inbox")
-                
-                Button {
-                    Task {
-                        await viewModel.resendVerificationEmail()
-                    }
-                } label: {
-                    HStack(spacing: 12) {
-                        Image(systemName: "envelope.fill")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(height: 24)
-                        
-                        Text("Resend email")
-                            .font(.system(size: 16, weight: .semibold))
-                            .frame(maxWidth: .infinity)
-                    }
-                    .foregroundColor(.black)
-                    .padding(.vertical, 16)
-                    .padding(.horizontal, 20)
-                    .frame(maxWidth: .infinity)
-                    .background(.appOcher)
-                    .cornerRadius(12)
+                Spacer().frame(height: 40)
+
+                Text("Verify your email")
+                    .font(.title2).bold()
+                    .foregroundColor(.appBlue)
+
+                Text("We sent a verification link to your email. Please tap the link, then return to the app.")
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.primary)
+                    .padding(.horizontal, 24)
+
+                // Status indicator
+                HStack(spacing: 8) {
+                    ProgressView().tint(.appRed)
+                    Text("Waiting for verification…")
+                        .foregroundColor(.secondary)
                 }
-                .padding(.horizontal, 20)
-                
+
+                // Resend with cooldown
+                ResendEmailButton()
+                    .environmentObject(viewModel)
+                    .padding(.horizontal, 20)
+
                 Button {
-                    Task {
-                        await viewModel.logout()
-                    }
+                    Task { await viewModel.logout() }
                 } label: {
                     HStack(spacing: 12) {
                         Image(systemName: "eraser.fill")
                             .resizable()
                             .scaledToFit()
                             .frame(height: 24)
-                        
                         Text("Log out")
                             .font(.system(size: 16, weight: .semibold))
                             .frame(maxWidth: .infinity)
@@ -66,9 +61,11 @@ struct VerifyEmailView: View {
                     .cornerRadius(12)
                 }
                 .padding(.horizontal, 20)
+
+                Spacer()
             }
         }
-        .onReceive(Timer.publish(every: 10.0, on: .main, in: .common).autoconnect()) { _ in
+        .onReceive(Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()) { _ in
             Task {
                 await viewModel.reloadUser()
             }
@@ -78,6 +75,57 @@ struct VerifyEmailView: View {
                 // When verification flips to true, the app root (SwiftiesApp) will update
                 // and transition to MainView if gating is set there. If this view is in a
                 // navigation stack, dismiss or navigate forward as needed.
+            }
+        }
+    }
+}
+
+struct ResendEmailButton: View {
+    @EnvironmentObject var viewModel: AuthViewModel
+    @State private var cooldown: Int = 30
+    @State private var canResend: Bool = true
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Button {
+                guard canResend else { return }
+                Task { await viewModel.resendVerificationEmail() }
+                startCooldown()
+            } label: {
+                HStack(spacing: 12) {
+                    Image(systemName: "envelope.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(height: 24)
+
+                    Text(canResend ? "Resend email" : "Resend in \(cooldown)s")
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                }
+                .foregroundColor(.black)
+                .padding(.vertical, 16)
+                .padding(.horizontal, 20)
+                .frame(maxWidth: .infinity)
+                .background(canResend ? Color.appOcher : Color.gray.opacity(0.4))
+                .cornerRadius(12)
+            }
+            .disabled(!canResend)
+
+            Text("Didn’t get the email? Check your spam folder.")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private func startCooldown() {
+        canResend = false
+        cooldown = 30
+        Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
+            if cooldown > 0 {
+                cooldown -= 1
+            } else {
+                canResend = true
+                timer.invalidate()
             }
         }
     }


### PR DESCRIPTION
This pull request introduces improvements to user authentication flow, email verification handling, and account management in the app. It refines how email verification is tracked and displayed, adds a cooldown for resending verification emails, and enables users to delete their accounts. Additionally, it updates the user profile photo storage and mapping for consistency.

**Authentication and Email Verification Improvements:**

* Changed `isEmailVerified` in `AuthViewModel` from a computed property to a published property, allowing real-time UI updates when email verification status changes. Also, updated logic to reload and track verification status. [[1]](diffhunk://#diff-99b26b414aef7c73913ce5638b9cbc0261b08691cef14c81a499b34f61949076R21) [[2]](diffhunk://#diff-99b26b414aef7c73913ce5638b9cbc0261b08691cef14c81a499b34f61949076L230-R231)
* Updated the main app navigation (`SwiftiesApp.swift`) to route new or incomplete users to onboarding, and improved gating logic for verified email and first-time users.
* Enhanced `VerifyEmailView` to provide clearer instructions, a status indicator, and a dedicated resend button with a cooldown timer. The UI now responds immediately to verification status changes, improving user experience.
* Added listeners in `LoginView` and `VerifyEmailView` to handle navigation and UI updates when email verification status changes. [[1]](diffhunk://#diff-1786c87140d2ef933939cf2fe73db2d79e0a6089d7974ffe3ac36297670d843aR45-R47) [[2]](diffhunk://#diff-190e204d9d2d45c0af63b13d57be34bb46d52f910aced6a1a3f124004fbee834L20-R128)

**Account Management Enhancements:**

* Added a "Delete your account" button to `ProfileView`, enabling users to initiate account deletion directly from their profile.

**User Profile Data Consistency:**

* Updated Firestore storage of profile photo to use the photo's absolute URL string, and changed the mapping in the `Profile` model so `avatarURL` maps to the "photo" field, ensuring consistency between storage and model. [[1]](diffhunk://#diff-c18f6dc23413408958f3bc593db7b5563e6e95ef05dcd5e1d107fc860eca165fL145-R145) [[2]](diffhunk://#diff-fea8bd12d6f4d9eba8280df50532de49e2c631f27414159389adc69cade2b541L34-R34)