### PR TITLE
Protect the start view cause it is Network only

### DIFF
--- a/Swifties/Services/EventNetworkService.swift
+++ b/Swifties/Services/EventNetworkService.swift
@@ -29,13 +29,13 @@ class EventNetworkService {
                 completion(.failure(NSError(
                     domain: "EventNetworkService",
                     code: -1,
-                    userInfo: [NSLocalizedDescriptionKey: "No se encontraron documentos"]
+                    userInfo: [NSLocalizedDescriptionKey: "No documents found"]
                 )))
                 return
             }
             
             let events = documents.compactMap { EventFactory.createEvent(from: $0) }
-            print("\(events.count) eventos obtenidos de Firestore")
+            print("\(events.count) events fetched from Firestore")
             completion(.success(events))
         }
     }

--- a/Swifties/Services/NetworkMonitor.swift
+++ b/Swifties/Services/NetworkMonitor.swift
@@ -6,15 +6,23 @@ final class NetworkMonitor: ObservableObject {
     static let shared = NetworkMonitor()
 
     private let monitor: NWPathMonitor
-    private let queue = DispatchQueue(label: "NetworkMonitorQueue")
+    private let queue = DispatchQueue(label: "NetworkMonitorQueue", qos: .background)
 
     @Published private(set) var isConnected: Bool = true
+    @Published private(set) var connectionType: NWInterface.InterfaceType?
 
     private init() {
         self.monitor = NWPathMonitor()
         monitor.pathUpdateHandler = { [weak self] path in
             DispatchQueue.main.async {
                 self?.isConnected = (path.status == .satisfied)
+                self?.connectionType = path.availableInterfaces.first?.type
+                
+                if path.status == .satisfied {
+                    print("Internet connection available")
+                } else {
+                    print("No Internet connection")
+                }
             }
         }
         monitor.start(queue: queue)
@@ -22,5 +30,9 @@ final class NetworkMonitor: ObservableObject {
 
     func currentConnectionAvailable() -> Bool {
         return isConnected
+    }
+
+    deinit {
+        monitor.cancel()
     }
 }

--- a/Swifties/Services/NetworkMonitorService.swift
+++ b/Swifties/Services/NetworkMonitorService.swift
@@ -28,9 +28,9 @@ class NetworkMonitorService {
             
             DispatchQueue.main.async {
                 if self?.isConnected == true {
-                    print("Conexión a Internet disponible")
+                    print("Internet connection available")
                 } else {
-                    print("Sin conexión a Internet")
+                    print("No Internet connection")
                 }
             }
         }

--- a/Swifties/ViewModels/WishMeLuckViewModel.swift
+++ b/Swifties/ViewModels/WishMeLuckViewModel.swift
@@ -272,7 +272,7 @@ class WishMeLuckViewModel: ObservableObject {
         return parseEventDocument(documents.randomElement())
     }
     
-    // MARK: - Parse Event Document (CORREGIDO)
+    // MARK: - Parse Event Document (FIXED)
     private func parseEventDocument(_ document: QueryDocumentSnapshot?) -> WishMeLuckEvent? {
         guard let doc = document else {
             print("   ⚠️ No document to parse")
@@ -281,13 +281,13 @@ class WishMeLuckViewModel: ObservableObject {
         
         print("   📝 Parsing event document ID: \(doc.documentID)")
         
-        // Usar EventFactory si existe, si no, parsing manual
+        // Use EventFactory if available, otherwise manual parsing
         if let event = EventFactory.createEvent(from: doc) {
             let wishMeLuckEvent = WishMeLuckEvent.fromEvent(event)
             print("   ✅ Parsed using EventFactory")
             return wishMeLuckEvent
         } else {
-            // Fallback a parsing manual
+            // Fallback to manual parsing
             let data = doc.data()
             let category = data["category"] as? String ?? "Unknown"
             let title = data["title"] as? String ?? data["name"] as? String ?? "Untitled Event"
@@ -311,7 +311,7 @@ class WishMeLuckViewModel: ObservableObject {
     // Note: This should only be called when user ACTUALLY ATTENDS the event
     // Not when they just get a recommendation
     func markEventAsAttended(eventId: String) async throws {
-        print("✅ Marking event as attended: \(eventId)")
+        print("Marking event as attended: \(eventId)")
         
         guard let userId = Auth.auth().currentUser?.uid else {
             throw NSError(domain: "WishMeLuck", code: 401,
@@ -332,7 +332,7 @@ class WishMeLuckViewModel: ObservableObject {
             "last_event_time": Timestamp(date: Date())
         ])
         
-        print("   ✅ User last event updated")
+        print("   😊 User last event updated")
     }
     
     // MARK: - Update Last Wished Date
@@ -385,7 +385,7 @@ class WishMeLuckViewModel: ObservableObject {
     
     // MARK: - Clear Event
     func clearEvent() {
-        print("🗑️ Clearing current event")
+        print("Clearing current event")
         currentEvent = nil
         error = nil
     }

--- a/Swifties/Views/LoginView.swift
+++ b/Swifties/Views/LoginView.swift
@@ -297,6 +297,7 @@ struct LoginView: View {
                 .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
                 
                 Button {
+                    // Check network connectivity FIRST
                     guard networkMonitor.currentConnectionAvailable() else {
                         alertMessage = "No network connection - Cannot send password reset"
                         showAlert = true
@@ -304,7 +305,9 @@ struct LoginView: View {
                         return
                     }
                     
+                    // Then validate email
                     let trimmedEmail = emailText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    
                     if trimmedEmail.isEmpty {
                         alertMessage = "Please enter your email address to reset your password."
                         showAlert = true

--- a/Swifties/Views/LoginView.swift
+++ b/Swifties/Views/LoginView.swift
@@ -340,10 +340,6 @@ struct LoginView: View {
             }
             .padding(.horizontal, 32)
         }
-        .onAppear {
-            // Accessing isConnected to trigger networkMonitor initialization if needed.
-            _ = networkMonitor.isConnected
-        }
         .alert("Let's fix that", isPresented: $showAlert, actions: {
             Button("OK", role: .cancel) {}
         }, message: {

--- a/Swifties/Views/LoginView.swift
+++ b/Swifties/Views/LoginView.swift
@@ -38,6 +38,26 @@ struct LoginView: View {
                 } else {
                     loginView
                 }
+                
+                // Floating connection status banner at the top
+                if !networkMonitor.isConnected {
+                    VStack {
+                        HStack(spacing: 8) {
+                            Image(systemName: "wifi.slash")
+                                .foregroundColor(.red)
+                            Text("No Internet Connection")
+                                .font(.callout)
+                                .foregroundColor(.red)
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(Color.red.opacity(0.1))
+                        .cornerRadius(8)
+                        .padding(.top, 8)
+                        
+                        Spacer()
+                    }
+                }
             }
             .onChange(of: viewModel.isAuthenticated) { _, isAuth in
                 if isAuth {
@@ -77,230 +97,251 @@ struct LoginView: View {
     
     // MARK: - Login View
     private var loginView: some View {
-        VStack(spacing: 24) {
-            Spacer().frame(height: 40)
-            
-            Text("Choose your login method")
-                .font(.system(size: 20, weight: .medium))
-                .foregroundColor(.black.opacity(0.7))
-            
-            Spacer().frame(height: 30)
-            
-            // Google Login Button
-            Button(action: {
-                guard networkMonitor.currentConnectionAvailable() else {
-                    alertMessage = "No network connection - Cannot log in"
-                    showAlert = true
-                    Analytics.logEvent("network_unavailable", parameters: ["context": "login"])
-                    return
-                }
-                Task {
-                    await viewModel.loginWithGoogle()
-                }
-            }) {
-                HStack(spacing: 12) {
-                    Group {
-                        if let _ = UIImage(named: "Google") {
-                            Image("Google")
-                                .resizable()
-                                .frame(width: 24, height: 24)
-                        } else {
-                            Image(systemName: "g.circle.fill")
-                                .font(.system(size: 24))
-                        }
+        ScrollView {
+            VStack(spacing: 24) {
+                Spacer().frame(height: 40)
+                
+                Text("Choose your login method")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundColor(.black.opacity(0.7))
+                
+                Spacer().frame(height: 30)
+                
+                // Google Login Button
+                Button(action: {
+                    guard networkMonitor.currentConnectionAvailable() else {
+                        alertMessage = "No network connection - Cannot log in"
+                        showAlert = true
+                        Analytics.logEvent("network_unavailable", parameters: ["context": "login"])
+                        return
                     }
-                    
-                    Text("Login with Google")
-                        .font(.system(size: 16, weight: .semibold))
-                        .frame(maxWidth: .infinity)
-                }
-                .foregroundColor(.white)
-                .padding(.vertical, 16)
-                .padding(.horizontal, 20)
-                .frame(maxWidth: .infinity)
-                .background(.appRed)
-                .cornerRadius(12)
-            }
-            .disabled(viewModel.isLoading)
-            .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
-            
-            // Twitter Login Button
-            Button(action: {
-                guard networkMonitor.currentConnectionAvailable() else {
-                    alertMessage = "No network connection - Cannot log in"
-                    showAlert = true
-                    Analytics.logEvent("network_unavailable", parameters: ["context": "login"])
-                    return
-                }
-                Task {
-                    await viewModel.loginWithTwitter()
-                }
-            }) {
-                HStack(spacing: 12) {
-                    Group {
-                        if let _ = UIImage(named: "Twitter") {
-                            Image("Twitter")
-                                .resizable()
-                                .frame(width: 24, height: 24)
-                        } else {
-                            Image(systemName: "bird.fill")
-                                .font(.system(size: 24))
-                        }
+                    Task {
+                        await viewModel.loginWithGoogle()
                     }
-                    
-                    Text("Login with Twitter")
-                        .font(.system(size: 16, weight: .semibold))
-                        .frame(maxWidth: .infinity)
-                }
-                .foregroundColor(.white)
-                .padding(.vertical, 16)
-                .padding(.horizontal, 20)
-                .frame(maxWidth: .infinity)
-                .background(.blue)
-                .cornerRadius(12)
-            }
-            .disabled(viewModel.isLoading)
-            .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
-            
-            Divider()
-                .padding(.horizontal, 20)
-            
-            // Email Login
-            TextField("Email", text: $emailText)
-                .autocapitalization(.none)
-                .disableAutocorrection(true)
-                .padding()
-                .background(Color(.secondarySystemBackground))
-                .cornerRadius(8)
+                }) {
+                    HStack(spacing: 12) {
+                        Group {
+                            if let _ = UIImage(named: "Google") {
+                                Image("Google")
+                                    .resizable()
+                                    .frame(width: 24, height: 24)
+                            } else {
+                                Image(systemName: "g.circle.fill")
+                                    .font(.system(size: 24))
+                            }
+                        }
                         
-            SecureField("Password", text: $passwordText)
-                .padding()
-                .background(Color(.secondarySystemBackground))
-                .cornerRadius(8)
-            
-            Button {
-                guard networkMonitor.currentConnectionAvailable() else {
-                    alertMessage = "No network connection - Cannot log in"
-                    showAlert = true
-                    Analytics.logEvent("network_unavailable", parameters: ["context": "login"])
-                    return
+                        Text("Login with Google")
+                            .font(.system(size: 16, weight: .semibold))
+                            .frame(maxWidth: .infinity)
+                    }
+                    .foregroundColor(.white)
+                    .padding(.vertical, 16)
+                    .padding(.horizontal, 20)
+                    .frame(maxWidth: .infinity)
+                    .background(.appRed)
+                    .cornerRadius(12)
                 }
-                let trimmedEmail = emailText.trimmingCharacters(in: .whitespacesAndNewlines)
-                let trimmedPassword = passwordText.trimmingCharacters(in: .whitespacesAndNewlines)
-                // Basic validations
-                if trimmedEmail.isEmpty || trimmedPassword.isEmpty {
-                    alertMessage = "Please enter both your email and password."
-                    showAlert = true
-                    return
+                .disabled(viewModel.isLoading)
+                .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+                
+                // Twitter Login Button
+                Button(action: {
+                    guard networkMonitor.currentConnectionAvailable() else {
+                        alertMessage = "No network connection - Cannot log in"
+                        showAlert = true
+                        Analytics.logEvent("network_unavailable", parameters: ["context": "login"])
+                        return
+                    }
+                    Task {
+                        await viewModel.loginWithTwitter()
+                    }
+                }) {
+                    HStack(spacing: 12) {
+                        Group {
+                            if let _ = UIImage(named: "Twitter") {
+                                Image("Twitter")
+                                    .resizable()
+                                    .frame(width: 24, height: 24)
+                            } else {
+                                Image(systemName: "bird.fill")
+                                    .font(.system(size: 24))
+                            }
+                        }
+                        
+                        Text("Login with Twitter")
+                            .font(.system(size: 16, weight: .semibold))
+                            .frame(maxWidth: .infinity)
+                    }
+                    .foregroundColor(.white)
+                    .padding(.vertical, 16)
+                    .padding(.horizontal, 20)
+                    .frame(maxWidth: .infinity)
+                    .background(.blue)
+                    .cornerRadius(12)
                 }
-                if !trimmedEmail.contains("@") || !trimmedEmail.contains(".") {
-                    alertMessage = "That doesn’t look like a valid email address. Please check and try again."
-                    showAlert = true
-                    return
+                .disabled(viewModel.isLoading)
+                .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+                
+                Divider()
+                    .padding(.horizontal, 20)
+                
+                // Email Login
+                TextField("Email", text: $emailText)
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)
+                    .padding()
+                    .background(Color(.secondarySystemBackground))
+                    .cornerRadius(8)
+                        
+                SecureField("Password", text: $passwordText)
+                    .padding()
+                    .background(Color(.secondarySystemBackground))
+                    .cornerRadius(8)
+                
+                Button {
+                    guard networkMonitor.currentConnectionAvailable() else {
+                        alertMessage = "No network connection - Cannot log in"
+                        showAlert = true
+                        Analytics.logEvent("network_unavailable", parameters: ["context": "login"])
+                        return
+                    }
+                    let trimmedEmail = emailText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let trimmedPassword = passwordText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    // Basic validations
+                    if trimmedEmail.isEmpty || trimmedPassword.isEmpty {
+                        alertMessage = "Please enter both your email and password."
+                        showAlert = true
+                        return
+                    }
+                    if !trimmedEmail.contains("@") || !trimmedEmail.contains(".") {
+                        alertMessage = "That doesn't look like a valid email address. Please check and try again."
+                        showAlert = true
+                        return
+                    }
+                    if trimmedPassword.count < 6 {
+                        alertMessage = "Your password must be at least 6 characters long (no blank spaces or new lines)."
+                        showAlert = true
+                        return
+                    }
+                    Task {
+                        await viewModel.loginWithEmail(email: trimmedEmail, password: trimmedPassword)
+                    }
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: "envelope.fill")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: 24)
+                        
+                        Text("Login with Email")
+                            .font(.system(size: 16, weight: .semibold))
+                            .frame(maxWidth: .infinity)
+                    }
+                    .foregroundColor(.white)
+                    .padding(.vertical, 16)
+                    .padding(.horizontal, 20)
+                    .frame(maxWidth: .infinity)
+                    .background(.gray)
+                    .cornerRadius(12)
                 }
-                if trimmedPassword.count < 6 {
-                    alertMessage = "Your password must be at least 6 characters long (no blank spaces or new lines)."
-                    showAlert = true
-                    return
+                .disabled(viewModel.isLoading)
+                .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+                
+                Button {
+                    guard networkMonitor.currentConnectionAvailable() else {
+                        alertMessage = "No network connection - Cannot register"
+                        showAlert = true
+                        Analytics.logEvent("network_unavailable", parameters: ["context": "register"])
+                        return
+                    }
+                    let trimmedEmail = emailText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let trimmedPassword = passwordText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if trimmedEmail.isEmpty || trimmedPassword.isEmpty {
+                        alertMessage = "Please provide both an email and a password to create your account."
+                        showAlert = true
+                        return
+                    }
+                    if !trimmedEmail.contains("@") || !trimmedEmail.contains(".") {
+                        alertMessage = "Please enter a valid email address before registering."
+                        showAlert = true
+                        return
+                    }
+                    if trimmedPassword.count < 6 {
+                        alertMessage = "Passwords need to be at least 6 characters. Try adding a few more without spaces or new lines."
+                        showAlert = true
+                        return
+                    }
+                    Task {
+                        await viewModel.registerWithEmail(email: trimmedEmail, password: trimmedPassword)
+                    }
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: "envelope")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: 24)
+                        
+                        Text("Register with Email")
+                            .font(.system(size: 16, weight: .semibold))
+                            .frame(maxWidth: .infinity)
+                    }
+                    .foregroundColor(.black.opacity(0.8))
+                    .padding(.vertical, 16)
+                    .padding(.horizontal, 20)
+                    .frame(maxWidth: .infinity)
+                    .background(.gray)
+                    .cornerRadius(12)
                 }
-                Task {
-                    await viewModel.loginWithEmail(email: trimmedEmail, password: trimmedPassword)
-                }
-            } label: {
-                HStack(spacing: 12) {
-                    Image(systemName: "envelope.fill")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(height: 24)
+                .disabled(viewModel.isLoading)
+                .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+                
+                Button {
+                    guard networkMonitor.currentConnectionAvailable() else {
+                        alertMessage = "No network connection - Cannot send password reset"
+                        showAlert = true
+                        Analytics.logEvent("network_unavailable", parameters: ["context": "forgot_password"])
+                        return
+                    }
                     
-                    Text("Login with Email")
-                        .font(.system(size: 16, weight: .semibold))
-                        .frame(maxWidth: .infinity)
-                }
-                .foregroundColor(.white)
-                .padding(.vertical, 16)
-                .padding(.horizontal, 20)
-                .frame(maxWidth: .infinity)
-                .background(.gray)
-                .cornerRadius(12)
-            }
-            .disabled(viewModel.isLoading)
-            .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
-            
-            Button {
-                guard networkMonitor.currentConnectionAvailable() else {
-                    alertMessage = "No network connection - Cannot register"
-                    showAlert = true
-                    Analytics.logEvent("network_unavailable", parameters: ["context": "register"])
-                    return
-                }
-                let trimmedEmail = emailText.trimmingCharacters(in: .whitespacesAndNewlines)
-                let trimmedPassword = passwordText.trimmingCharacters(in: .whitespacesAndNewlines)
-                if trimmedEmail.isEmpty || trimmedPassword.isEmpty {
-                    alertMessage = "Please provide both an email and a password to create your account."
-                    showAlert = true
-                    return
-                }
-                if !trimmedEmail.contains("@") || !trimmedEmail.contains(".") {
-                    alertMessage = "Please enter a valid email address before registering."
-                    showAlert = true
-                    return
-                }
-                if trimmedPassword.count < 6 {
-                    alertMessage = "Passwords need to be at least 6 characters. Try adding a few more without spaces or new lines."
-                    showAlert = true
-                    return
-                }
-                Task {
-                    await viewModel.registerWithEmail(email: trimmedEmail, password: trimmedPassword)
-                }
-            } label: {
-                HStack(spacing: 12) {
-                    Image(systemName: "envelope")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(height: 24)
+                    let trimmedEmail = emailText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if trimmedEmail.isEmpty {
+                        alertMessage = "Please enter your email address to reset your password."
+                        showAlert = true
+                        return
+                    }
+                    if !trimmedEmail.contains("@") || !trimmedEmail.contains(".") {
+                        alertMessage = "Please enter a valid email address."
+                        showAlert = true
+                        return
+                    }
                     
-                    Text("Register with Email")
-                        .font(.system(size: 16, weight: .semibold))
-                        .frame(maxWidth: .infinity)
+                    Task {
+                        await viewModel.sendPasswordReset(email: trimmedEmail)
+                    }
+                } label: {
+                    Text("Forgot Password?")
+                        .foregroundColor(.red)
+                        .underline()
                 }
-                .foregroundColor(.black.opacity(0.8))
-                .padding(.vertical, 16)
-                .padding(.horizontal, 20)
-                .frame(maxWidth: .infinity)
-                .background(.gray)
-                .cornerRadius(12)
-            }
-            .disabled(viewModel.isLoading)
-            .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
-            
-            Button {
-                Task {
-                    await viewModel.sendPasswordReset(email: emailText)
+                
+                Spacer().frame(height: 20)
+                
+                // Loading indicator
+                if viewModel.isLoading {
+                    ProgressView()
+                        .tint(.appRed)
                 }
-            } label: {
-                Text("Forgot Password?")
-                    .foregroundColor(.red)
-                    .underline()
+                
+                Spacer()
             }
-            
-            Spacer().frame(height: 20)
-            
-            // Loading indicator
-            if viewModel.isLoading {
-                ProgressView()
-                    .tint(.appRed)
-            }
-            
-            Spacer()
+            .padding(.horizontal, 32)
         }
         .onAppear {
             // Accessing isConnected to trigger networkMonitor initialization if needed.
             _ = networkMonitor.isConnected
         }
-        .padding(.horizontal, 32)
-        .alert("Let’s fix that", isPresented: $showAlert, actions: {
+        .alert("Let's fix that", isPresented: $showAlert, actions: {
             Button("OK", role: .cancel) {}
         }, message: {
             Text(alertMessage)

--- a/Swifties/Views/StartView.swift
+++ b/Swifties/Views/StartView.swift
@@ -1,14 +1,15 @@
 //
-//  StartView.swift
-//  Swifties
-//
-//  Created by Juan Esteban Vasquez Parra on 29/09/25.
+// StartView.swift
+// Swifties
+// Created by Natalia Villegas Calderón on 1/10/25.
 //
 
 import SwiftUI
 
 struct StartView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
+    @StateObject private var networkMonitor = NetworkMonitor.shared
+    @State private var showNoConnectionAlert = false
     
     var body: some View {
         ZStack {
@@ -39,23 +40,54 @@ struct StartView: View {
                 
                 Spacer()
                 
-                HStack(spacing: 12) {
-                    NavigationLink(destination: LoginView()
-                        .environmentObject(authViewModel)) {
-                        Text("Log In")
-                            .font(.title3.weight(.bold))
-                            .foregroundColor(.white)
-                            .frame(width: 120, height: 45)
+                // Connection status indicator
+                if !networkMonitor.isConnected {
+                    HStack(spacing: 8) {
+                        Image(systemName: "wifi.slash")
+                            .foregroundColor(.red)
+                        Text("No Internet Connection")
+                            .font(.callout)
+                            .foregroundColor(.red)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .tint(Color("appBlue"))
-                    
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(Color.red.opacity(0.1))
+                    .cornerRadius(8)
+                }
+                
+                HStack(spacing: 12) {
+                    if networkMonitor.isConnected {
+                        NavigationLink(destination: LoginView()
+                            .environmentObject(authViewModel)) {
+                            Text("Log In")
+                                .font(.title3.weight(.bold))
+                                .foregroundColor(.white)
+                                .frame(width: 120, height: 45)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(Color("appBlue"))
+                    } else {
+                        Button {
+                            showNoConnectionAlert = true
+                        } label: {
+                            Text("Log In")
+                                .font(.title3.weight(.bold))
+                                .foregroundColor(.white)
+                                .frame(width: 120, height: 45)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(Color.gray)
+                        // Remove .disabled(true) so the button can be tapped
+                    }
                 }
                 
                 Spacer()
-
-            
             }
+        }
+        .alert("No Internet Connection", isPresented: $showNoConnectionAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text("Please check your internet connection and try again.")
         }
     }
 }

--- a/Swifties/Views/StartView.swift
+++ b/Swifties/Views/StartView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 struct StartView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
-    @StateObject private var networkMonitor = NetworkMonitor.shared
+    @ObservedObject private var networkMonitor = NetworkMonitor.shared
     @State private var showNoConnectionAlert = false
     
     var body: some View {

--- a/Swifties/Views/WishMeLuck.swift
+++ b/Swifties/Views/WishMeLuck.swift
@@ -145,8 +145,7 @@ struct WishMeLuckView: View {
                     return
                 }
                                 
-                // Try to parse using Codable first
-                // Opción 1: Usando EventFactory (recomendado si ya lo tienes)
+                // Option 1: Using EventFactory (recommended if you already have it)
                 if let event = EventFactory.createEvent(from: document) {
                     print("✅ Successfully parsed event using EventFactory")
                     fullEventForDetail = event


### PR DESCRIPTION
Closes #137

This pull request introduces several improvements focused on user experience and code clarity, particularly around network connectivity and English language consistency. The main enhancements include adding visible network status indicators to key views, refining network monitoring logic, and updating user-facing messages and comments to English for consistency.

**Network connectivity improvements:**

* Added a floating "No Internet Connection" banner to `LoginView` and a connection status indicator to `StartView`, improving user awareness of network status. The login button in `StartView` now remains tappable when offline but shows an alert instead of proceeding. 

**User experience enhancements:**

* Added network connectivity checks before password reset actions in `LoginView`, displaying alerts and logging analytics events if the network is unavailable. Improved validation and alert messaging for password reset.

**Language and code clarity updates:**

* Changed print statements, error messages, and comments throughout the codebase from Spanish to English for consistency and clarity, including in `EventNetworkService`, `WishMeLuckViewModel`, and `NetworkMonitorService`.

**Minor UI and code improvements:**

* Switched the main login view to use a `ScrollView` for better layout handling, and adjusted padding and alert titles for consistency. 
* Updated authorship comment in `StartView.swift` to reflect the correct creator.