### PR TITLE
Three-layer-cache in weekly challengue

### DIFF
--- a/Swifties.xcodeproj/project.pbxproj
+++ b/Swifties.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		882B00692EB10437003042A5 /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = 882B00682EB10437003042A5 /* SQLite */; };
+		884694CB2EB3D84A0068BD86 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 884694CA2EB3D84A0068BD86 /* RealmSwift */; };
 		E165F9152E921FD4001D8B00 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = E165F9142E921FD4001D8B00 /* FirebaseCrashlytics */; };
 		E168A9662E8DC88A00BAF013 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = E168A9652E8DC88A00BAF013 /* GoogleSignIn */; };
 		E168A9682E8DC88A00BAF013 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E168A9672E8DC88A00BAF013 /* GoogleSignInSwift */; };
@@ -87,6 +88,7 @@
 				E165F9152E921FD4001D8B00 /* FirebaseCrashlytics in Frameworks */,
 				882B00692EB10437003042A5 /* SQLite in Frameworks */,
 				E1822BF22E8C4CF6008FC420 /* FirebaseAI in Frameworks */,
+				884694CB2EB3D84A0068BD86 /* RealmSwift in Frameworks */,
 				E168A9662E8DC88A00BAF013 /* GoogleSignIn in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -150,6 +152,7 @@
 				E168A9672E8DC88A00BAF013 /* GoogleSignInSwift */,
 				E165F9142E921FD4001D8B00 /* FirebaseCrashlytics */,
 				882B00682EB10437003042A5 /* SQLite */,
+				884694CA2EB3D84A0068BD86 /* RealmSwift */,
 			);
 			productName = Swifties;
 			productReference = E1544D252E885ABB00B3320D /* Swifties.app */;
@@ -238,6 +241,7 @@
 				E1822BF02E8C4CF6008FC420 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				E168A9642E8DC88A00BAF013 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				882B00672EB10437003042A5 /* XCRemoteSwiftPackageReference "SQLite" */,
+				884694C92EB3D84A0068BD86 /* XCRemoteSwiftPackageReference "realm-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E1A16D442E84BD9A003D5B39;
@@ -687,6 +691,14 @@
 				minimumVersion = 0.15.4;
 			};
 		};
+		884694C92EB3D84A0068BD86 /* XCRemoteSwiftPackageReference "realm-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/realm-swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.45.0;
+			};
+		};
 		E168A9642E8DC88A00BAF013 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/google/GoogleSignIn-iOS";
@@ -710,6 +722,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 882B00672EB10437003042A5 /* XCRemoteSwiftPackageReference "SQLite" */;
 			productName = SQLite;
+		};
+		884694CA2EB3D84A0068BD86 /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 884694C92EB3D84A0068BD86 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
 		};
 		E165F9142E921FD4001D8B00 /* FirebaseCrashlytics */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Swifties.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Swifties.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dff16e089df6e707860379f33d6451bb2308e7545fb3225cdf04ffd6c5e88cac",
+  "originHash" : "ed59d4e048fcb75d9f572172b5a9db5aa4889be1bca0a1376782ea66f3d5632b",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -143,6 +143,24 @@
       "state" : {
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "realm-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-core.git",
+      "state" : {
+        "revision" : "cccb3ca9e26ec452a29f2f0d4050d1e38b8a3d43",
+        "version" : "14.14.0"
+      }
+    },
+    {
+      "identity" : "realm-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-swift.git",
+      "state" : {
+        "revision" : "1c105d34f25af7851c5a3ff146be006de247a6b4",
+        "version" : "10.54.6"
       }
     },
     {

--- a/Swifties/Models/WeeklyChallengeChartData.swift
+++ b/Swifties/Models/WeeklyChallengeChartData.swift
@@ -1,5 +1,5 @@
 //
-//  ChartData.swift
+//  WeeklyChallengeChartData.swift
 //  Swifties
 //
 //  Created by Imac  on 4/10/25.
@@ -7,8 +7,19 @@
 
 import Foundation
 
-struct WeeklyChallengeChartData: Identifiable {
-    let id = UUID()
+struct WeeklyChallengeChartData: Identifiable, Codable {
+    let id: UUID
     let label: String
     let count: Int
+    
+    init(label: String, count: Int) {
+        self.id = UUID()
+        self.label = label
+        self.count = count
+    }
+    
+    // Codable conformance
+    enum CodingKeys: String, CodingKey {
+        case id, label, count
+    }
 }

--- a/Swifties/Models/WeeklyChallengeModels.swift
+++ b/Swifties/Models/WeeklyChallengeModels.swift
@@ -1,0 +1,85 @@
+//
+//  WeeklyChallengeModels.swift
+//  Swifties
+//
+//  Models for Weekly Challenge with Realm support
+//
+
+import Foundation
+import RealmSwift
+
+// MARK: - Realm Models
+
+class RealmWeeklyChallengeData: Object {
+    @Persisted(primaryKey: true) var userId: String
+    @Persisted var weekIdentifier: String // "2025-W44"
+    @Persisted var eventData: Data? // Serialized Event
+    @Persisted var hasAttended: Bool = false
+    @Persisted var totalChallenges: Int = 0
+    @Persisted var lastUpdated: Date = Date()
+    @Persisted var chartData: List<RealmChartData>
+    
+    convenience init(userId: String, weekIdentifier: String, eventData: Data?, hasAttended: Bool, totalChallenges: Int, chartData: [WeeklyChallengeChartData]) {
+        self.init()
+        self.userId = userId
+        self.weekIdentifier = weekIdentifier
+        self.eventData = eventData
+        self.hasAttended = hasAttended
+        self.totalChallenges = totalChallenges
+        self.lastUpdated = Date()
+        
+        let realmChartData = List<RealmChartData>()
+        chartData.forEach { data in
+            let realmData = RealmChartData()
+            realmData.label = data.label
+            realmData.count = data.count
+            realmChartData.append(realmData)
+        }
+        self.chartData = realmChartData
+    }
+}
+
+class RealmChartData: Object {
+    @Persisted var label: String = ""
+    @Persisted var count: Int = 0
+}
+
+// MARK: - Weekly Challenge Cache Model (In-Memory)
+
+struct WeeklyChallengeCache {
+    let event: Event?
+    let hasAttended: Bool
+    let totalChallenges: Int
+    let chartData: [WeeklyChallengeChartData]
+    let timestamp: Date
+    
+    var isValid: Bool {
+        // Cache válido por 1 hora
+        Date().timeIntervalSince(timestamp) < 3600
+    }
+}
+
+// MARK: - Conversion Extensions
+
+extension RealmWeeklyChallengeData {
+    func toCache(event: Event?) -> WeeklyChallengeCache {
+        WeeklyChallengeCache(
+            event: event,
+            hasAttended: hasAttended,
+            totalChallenges: totalChallenges,
+            chartData: chartData.map { WeeklyChallengeChartData(label: $0.label, count: $0.count) },
+            timestamp: lastUpdated
+        )
+    }
+}
+
+// MARK: - Week Identifier Helper
+
+extension Date {
+    func weekIdentifier() -> String {
+        let calendar = Calendar.current
+        let year = calendar.component(.year, from: self)
+        let week = calendar.component(.weekOfYear, from: self)
+        return "\(year)-W\(String(format: "%02d", week))"
+    }
+}

--- a/Swifties/Models/WeeklyChallengeModels.swift
+++ b/Swifties/Models/WeeklyChallengeModels.swift
@@ -54,7 +54,7 @@ struct WeeklyChallengeCache {
     let timestamp: Date
     
     var isValid: Bool {
-        // Cache válido por 1 hora
+        // Cache valid for 1 hour
         Date().timeIntervalSince(timestamp) < 3600
     }
 }

--- a/Swifties/Services/UserEventStorageService.swift
+++ b/Swifties/Services/UserEventStorageService.swift
@@ -10,29 +10,47 @@ import Foundation
 class UserEventStorageService {
     static let shared = UserEventStorageService()
     
-    private let databaseManager = UserEventDatabaseManager.shared
     private let userDefaults = UserDefaults.standard
+    private let eventsKey = "user_events"
+    private let slotsKey = "user_free_time_slots"
     private let timestampKey = "user_events_timestamp"
     private let storageExpirationHours = 12.0 // Shorter because it depends on preferences
     
     private init() {}
     
     func saveUserEventsToStorage(_ events: [Event], freeTimeSlots: [FreeTimeSlot], userId: String) {
-        // Save to SQLite
-        databaseManager.saveUserEvents(events, freeTimeSlots: freeTimeSlots, userId: userId)
+        // Convert to Codable
+        let codableEvents = events.map { $0.toCodable() }
+        let codableSlots = freeTimeSlots.map { CodableFreeTimeSlot(from: $0) }
         
-        // Save timestamp
-        let key = "\(timestampKey)_\(userId)"
-        userDefaults.set(Date(), forKey: key)
-        userDefaults.synchronize()
+        // Encode to JSON
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
         
-        print("User events saved to storage: \(events.count) events, \(freeTimeSlots.count) slots")
+        do {
+            let eventsData = try encoder.encode(codableEvents)
+            let slotsData = try encoder.encode(codableSlots)
+            
+            // Save with userId prefix
+            let eventsKey = "\(self.eventsKey)_\(userId)"
+            let slotsKey = "\(self.slotsKey)_\(userId)"
+            let timestampKey = "\(self.timestampKey)_\(userId)"
+            
+            userDefaults.set(eventsData, forKey: eventsKey)
+            userDefaults.set(slotsData, forKey: slotsKey)
+            userDefaults.set(Date(), forKey: timestampKey)
+            userDefaults.synchronize()
+            
+            print("User events saved to UserDefaults: \(events.count) events, \(freeTimeSlots.count) slots")
+        } catch {
+            print("Error encoding user events: \(error.localizedDescription)")
+        }
     }
     
     func loadUserEventsFromStorage(userId: String) -> (events: [Event], slots: [FreeTimeSlot])? {
         // Check if data has expired
-        let key = "\(timestampKey)_\(userId)"
-        if let timestamp = userDefaults.object(forKey: key) as? Date {
+        let timestampKey = "\(self.timestampKey)_\(userId)"
+        if let timestamp = userDefaults.object(forKey: timestampKey) as? Date {
             let hoursElapsed = Date().timeIntervalSince(timestamp) / 3600
             print("User events storage age: \(String(format: "%.1f", hoursElapsed)) hours")
             
@@ -45,29 +63,54 @@ class UserEventStorageService {
             return nil
         }
         
-        // Load from SQLite
-        guard let data = databaseManager.loadUserEvents(userId: userId) else {
-            print("No user events found in storage")
+        // Load from UserDefaults
+        let eventsKey = "\(self.eventsKey)_\(userId)"
+        let slotsKey = "\(self.slotsKey)_\(userId)"
+        
+        guard let eventsData = userDefaults.data(forKey: eventsKey),
+              let slotsData = userDefaults.data(forKey: slotsKey) else {
+            print("No user events found in UserDefaults")
             return nil
         }
         
-        print("User events loaded from storage: \(data.events.count) events, \(data.slots.count) slots")
-        return data
+        // Decode from JSON
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        
+        do {
+            let codableEvents = try decoder.decode([CodableEvent].self, from: eventsData)
+            let codableSlots = try decoder.decode([CodableFreeTimeSlot].self, from: slotsData)
+            
+            let events = codableEvents.map { Event.from(codable: $0) }
+            let slots = codableSlots.map { $0.toFreeTimeSlot() }
+            
+            print("User events loaded from UserDefaults: \(events.count) events, \(slots.count) slots")
+            return (events: events, slots: slots)
+        } catch {
+            print("Error decoding user events: \(error.localizedDescription)")
+            clearStorage(userId: userId)
+            return nil
+        }
     }
     
     func clearStorage(userId: String) {
-        databaseManager.deleteUserEvents(userId: userId)
-        let key = "\(timestampKey)_\(userId)"
-        userDefaults.removeObject(forKey: key)
+        let eventsKey = "\(self.eventsKey)_\(userId)"
+        let slotsKey = "\(self.slotsKey)_\(userId)"
+        let timestampKey = "\(self.timestampKey)_\(userId)"
+        
+        userDefaults.removeObject(forKey: eventsKey)
+        userDefaults.removeObject(forKey: slotsKey)
+        userDefaults.removeObject(forKey: timestampKey)
         userDefaults.synchronize()
+        
         print("User events storage cleared for user: \(userId)")
     }
     
     func debugStorage(userId: String) {
-        print("\n=== DEBUG USER EVENTS STORAGE ===")
+        print("\n=== DEBUG USER EVENTS STORAGE (UserDefaults) ===")
         
-        let key = "\(timestampKey)_\(userId)"
-        if let timestamp = userDefaults.object(forKey: key) as? Date {
+        let timestampKey = "\(self.timestampKey)_\(userId)"
+        if let timestamp = userDefaults.object(forKey: timestampKey) as? Date {
             let hoursElapsed = Date().timeIntervalSince(timestamp) / 3600
             print("Timestamp: \(timestamp)")
             print("Age: \(String(format: "%.1f", hoursElapsed)) hours")
@@ -75,14 +118,30 @@ class UserEventStorageService {
             print("No timestamp")
         }
         
-        databaseManager.debugDatabase(userId: userId)
+        let eventsKey = "\(self.eventsKey)_\(userId)"
+        let slotsKey = "\(self.slotsKey)_\(userId)"
         
-        print("=================================\n")
+        if let eventsData = userDefaults.data(forKey: eventsKey),
+           let slotsData = userDefaults.data(forKey: slotsKey) {
+            print("Events data size: \(eventsData.count) bytes")
+            print("Slots data size: \(slotsData.count) bytes")
+            
+            let decoder = JSONDecoder()
+            if let events = try? decoder.decode([CodableEvent].self, from: eventsData),
+               let slots = try? decoder.decode([CodableFreeTimeSlot].self, from: slotsData) {
+                print("Events count: \(events.count)")
+                print("Slots count: \(slots.count)")
+            }
+        } else {
+            print("No data found in UserDefaults")
+        }
+        
+        print("=================================================\n")
     }
     
     func getStorageInfo(userId: String) -> UserEventStorageInfo {
-        let key = "\(timestampKey)_\(userId)"
-        let timestamp = userDefaults.object(forKey: key) as? Date
+        let timestampKey = "\(self.timestampKey)_\(userId)"
+        let timestamp = userDefaults.object(forKey: timestampKey) as? Date
         let isExpired: Bool
         
         if let timestamp = timestamp {
@@ -97,6 +156,23 @@ class UserEventStorageService {
             isExpired: isExpired
         )
     }
+    
+    func getStorageSize(userId: String) -> Int {
+        let eventsKey = "\(self.eventsKey)_\(userId)"
+        let slotsKey = "\(self.slotsKey)_\(userId)"
+        
+        var totalSize = 0
+        
+        if let eventsData = userDefaults.data(forKey: eventsKey) {
+            totalSize += eventsData.count
+        }
+        
+        if let slotsData = userDefaults.data(forKey: slotsKey) {
+            totalSize += slotsData.count
+        }
+        
+        return totalSize
+    }
 }
 
 // MARK: - Storage Info Model
@@ -108,5 +184,25 @@ struct UserEventStorageInfo {
     var ageInHours: Double? {
         guard let lastUpdate = lastUpdate else { return nil }
         return Date().timeIntervalSince(lastUpdate) / 3600
+    }
+}
+
+// MARK: - Codable FreeTimeSlot
+
+struct CodableFreeTimeSlot: Codable {
+    let id: String
+    let day: String
+    let start: String
+    let end: String
+    
+    init(from slot: FreeTimeSlot) {
+        self.id = slot.id
+        self.day = slot.day
+        self.start = slot.start
+        self.end = slot.end
+    }
+    
+    func toFreeTimeSlot() -> FreeTimeSlot {
+        FreeTimeSlot(id: id, day: day, start: start, end: end)
     }
 }

--- a/Swifties/Services/WeeklyChallengeCacheService.swift
+++ b/Swifties/Services/WeeklyChallengeCacheService.swift
@@ -1,0 +1,93 @@
+//
+//  WeeklyChallengeCacheService.swift
+//  Swifties
+//
+//  Layer 1: In-Memory Cache for Weekly Challenge
+//
+
+import Foundation
+
+class WeeklyChallengeCacheService {
+    static let shared = WeeklyChallengeCacheService()
+    
+    private var cache: [String: WeeklyChallengeCache] = [:]
+    private let cacheExpirationSeconds: TimeInterval = 3600 // 1 hour
+    
+    private init() {}
+    
+    // MARK: - Cache Operations
+    
+    func getCachedChallenge(userId: String) -> WeeklyChallengeCache? {
+        let weekId = Date().weekIdentifier()
+        let key = "\(userId)_\(weekId)"
+        
+        guard let cached = cache[key] else {
+            print("❌ No cache found for key: \(key)")
+            return nil
+        }
+        
+        // Check if cache is still valid
+        let age = Date().timeIntervalSince(cached.timestamp)
+        if age > cacheExpirationSeconds {
+            print("⏰ Cache expired (age: \(String(format: "%.1f", age/60)) minutes)")
+            cache.removeValue(forKey: key)
+            return nil
+        }
+        
+        print("✅ Cache hit for key: \(key) (age: \(String(format: "%.1f", age/60)) minutes)")
+        return cached
+    }
+    
+    func cacheChallenge(userId: String, event: Event?, hasAttended: Bool, totalChallenges: Int, chartData: [WeeklyChallengeChartData]) {
+        let weekId = Date().weekIdentifier()
+        let key = "\(userId)_\(weekId)"
+        
+        let cache = WeeklyChallengeCache(
+            event: event,
+            hasAttended: hasAttended,
+            totalChallenges: totalChallenges,
+            chartData: chartData,
+            timestamp: Date()
+        )
+        
+        self.cache[key] = cache
+        print("💾 Cached challenge for key: \(key)")
+    }
+    
+    func clearCache(userId: String) {
+        let weekId = Date().weekIdentifier()
+        let key = "\(userId)_\(weekId)"
+        cache.removeValue(forKey: key)
+        print("🗑️ Cache cleared for key: \(key)")
+    }
+    
+    func clearAllCache() {
+        cache.removeAll()
+        print("🗑️ All cache cleared")
+    }
+    
+    // MARK: - Debug
+    
+    func debugCache(userId: String) {
+        let weekId = Date().weekIdentifier()
+        let key = "\(userId)_\(weekId)"
+        
+        print("\n=== DEBUG WEEKLY CHALLENGE CACHE ===")
+        print("Key: \(key)")
+        
+        if let cached = cache[key] {
+            let age = Date().timeIntervalSince(cached.timestamp)
+            print("Found: YES")
+            print("Age: \(String(format: "%.1f", age/60)) minutes")
+            print("Event: \(cached.event?.name ?? "nil")")
+            print("Has Attended: \(cached.hasAttended)")
+            print("Total Challenges: \(cached.totalChallenges)")
+            print("Valid: \(cached.isValid)")
+        } else {
+            print("Found: NO")
+        }
+        
+        print("Total cached items: \(cache.count)")
+        print("=====================================\n")
+    }
+}

--- a/Swifties/Services/WeeklyChallengeNetworkService.swift
+++ b/Swifties/Services/WeeklyChallengeNetworkService.swift
@@ -1,0 +1,270 @@
+//
+//  WeeklyChallengeNetworkService.swift
+//  Swifties
+//
+//  Layer 3: Network Service for Weekly Challenge
+//
+
+import Foundation
+import FirebaseFirestore
+import FirebaseAuth
+
+struct WeeklyChallengeData {
+    let event: Event?
+    let hasAttended: Bool
+    let totalChallenges: Int
+    let chartData: [WeeklyChallengeChartData]
+}
+
+class WeeklyChallengeNetworkService {
+    static let shared = WeeklyChallengeNetworkService()
+    
+    private let db = Firestore.firestore(database: "default")
+    
+    private init() {}
+    
+    // MARK: - Fetch Complete Challenge Data
+    
+    func fetchChallengeData(userId: String, completion: @escaping (Result<WeeklyChallengeData, Error>) -> Void) {
+        print("🌐 Fetching challenge data from network...")
+        
+        let group = DispatchGroup()
+        
+        var fetchedEvent: Event?
+        var fetchedHasAttended = false
+        var fetchedTotalChallenges = 0
+        var fetchedChartData: [WeeklyChallengeChartData] = []
+        var fetchError: Error?
+        
+        // 1. Load Random Event
+        group.enter()
+        loadRandomEvent { result in
+            switch result {
+            case .success(let event):
+                fetchedEvent = event
+                
+                // Check if attended
+                group.enter()
+                self.checkIfUserAttended(userId: userId, eventId: event.name) { attended in
+                    fetchedHasAttended = attended
+                    group.leave()
+                }
+                
+            case .failure(let error):
+                fetchError = error
+            }
+            group.leave()
+        }
+        
+        // 2. Load Stats
+        group.enter()
+        loadUserChallengeStats(userId: userId) { result in
+            switch result {
+            case .success(let stats):
+                fetchedTotalChallenges = stats
+            case .failure(let error):
+                print("⚠️ Error loading stats: \(error.localizedDescription)")
+            }
+            group.leave()
+        }
+        
+        // 3. Load Chart Data
+        group.enter()
+        loadLast30DaysData(userId: userId) { result in
+            switch result {
+            case .success(let data):
+                fetchedChartData = data
+            case .failure(let error):
+                print("⚠️ Error loading chart data: \(error.localizedDescription)")
+            }
+            group.leave()
+        }
+        
+        // Notify when all done
+        group.notify(queue: .main) {
+            if let error = fetchError {
+                completion(.failure(error))
+            } else {
+                let data = WeeklyChallengeData(
+                    event: fetchedEvent,
+                    hasAttended: fetchedHasAttended,
+                    totalChallenges: fetchedTotalChallenges,
+                    chartData: fetchedChartData
+                )
+                print("✅ Network fetch completed")
+                completion(.success(data))
+            }
+        }
+    }
+    
+    // MARK: - Mark as Attending
+    
+    func markAsAttending(userId: String, event: Event, completion: @escaping (Result<Void, Error>) -> Void) {
+        let activityData: [String: Any] = [
+            "event_id": event.name,
+            "source": "weekly_challenge",
+            "time": Timestamp(date: Date()),
+            "time_of_day": getCurrentTimeOfDay(),
+            "type": "weekly_challenge",
+            "user_id": userId,
+            "with_friends": false
+        ]
+        
+        print("🔵 Saving activity to network...")
+        
+        db.collection("user_activities").addDocument(data: activityData) { error in
+            if let error = error {
+                print("❌ Error saving activity: \(error.localizedDescription)")
+                completion(.failure(error))
+            } else {
+                print("✅ Activity saved to network")
+                
+                // Update user's last event
+                self.updateUserLastEvent(userId: userId, event: event, completion: completion)
+            }
+        }
+    }
+    
+    private func updateUserLastEvent(userId: String, event: Event, completion: @escaping (Result<Void, Error>) -> Void) {
+        let userRef = db.collection("users").document(userId)
+        
+        userRef.updateData([
+            "last_event": event.name,
+            "last_event_time": Timestamp(date: Date()),
+            "event_last_category": event.category
+        ]) { error in
+            if let error = error {
+                print("❌ Error updating last_event: \(error.localizedDescription)")
+                completion(.failure(error))
+            } else {
+                print("✅ User's last_event updated")
+                completion(.success(()))
+            }
+        }
+    }
+    
+    // MARK: - Private Helper Methods
+    
+    private func checkIfUserAttended(userId: String, eventId: String, completion: @escaping (Bool) -> Void) {
+        db.collection("user_activities")
+            .whereField("user_id", isEqualTo: userId)
+            .whereField("event_id", isEqualTo: eventId)
+            .whereField("type", isEqualTo: "weekly_challenge")
+            .getDocuments { snapshot, error in
+                if let error = error {
+                    print("❌ Error checking attendance: \(error.localizedDescription)")
+                    completion(false)
+                    return
+                }
+                
+                let attended = (snapshot?.documents.count ?? 0) > 0
+                print(attended ? "✅ User attended" : "❌ User not attended")
+                completion(attended)
+            }
+    }
+    
+    private func loadUserChallengeStats(userId: String, completion: @escaping (Result<Int, Error>) -> Void) {
+        db.collection("user_activities")
+            .whereField("user_id", isEqualTo: userId)
+            .whereField("type", isEqualTo: "weekly_challenge")
+            .getDocuments { snapshot, error in
+                if let error = error {
+                    completion(.failure(error))
+                    return
+                }
+                
+                let count = snapshot?.documents.count ?? 0
+                completion(.success(count))
+            }
+    }
+    
+    private func loadLast30DaysData(userId: String, completion: @escaping (Result<[WeeklyChallengeChartData], Error>) -> Void) {
+        var calendar = Calendar.current
+        calendar.firstWeekday = 2
+        
+        let currentDate = Date()
+        
+        db.collection("user_activities")
+            .whereField("user_id", isEqualTo: userId)
+            .whereField("type", isEqualTo: "weekly_challenge")
+            .getDocuments { snapshot, error in
+                if let error = error {
+                    completion(.failure(error))
+                    return
+                }
+                
+                var activityDates: [Date] = []
+                if let documents = snapshot?.documents {
+                    for doc in documents {
+                        if let timestamp = doc.data()["time"] as? Timestamp {
+                            activityDates.append(timestamp.dateValue())
+                        }
+                    }
+                }
+                
+                var chartData: [WeeklyChallengeChartData] = []
+                
+                for i in 0..<4 {
+                    let weeksAgo = 3 - i
+                    let targetDate = calendar.date(byAdding: .weekOfYear, value: -weeksAgo, to: currentDate) ?? currentDate
+                    
+                    guard let weekInterval = calendar.dateInterval(of: .weekOfYear, for: targetDate) else {
+                        continue
+                    }
+                    
+                    let activitiesInWeek = activityDates.filter { activityDate in
+                        activityDate >= weekInterval.start && activityDate < weekInterval.end
+                    }
+                    
+                    let label = weeksAgo == 0 ? "This Week" : "\(weeksAgo)w ago"
+                    let hasCompleted = !activitiesInWeek.isEmpty
+                    chartData.append(WeeklyChallengeChartData(label: label, count: hasCompleted ? 1 : 0))
+                }
+                
+                completion(.success(chartData))
+            }
+    }
+    
+    private func loadRandomEvent(completion: @escaping (Result<Event, Error>) -> Void) {
+        var calendar = Calendar.current
+        calendar.firstWeekday = 2
+        
+        let weekOfYear = calendar.component(.weekOfYear, from: Date())
+        let year = calendar.component(.year, from: Date())
+        
+        db.collection("events").getDocuments { snapshot, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            
+            guard let documents = snapshot?.documents, !documents.isEmpty else {
+                let error = NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "No events available"])
+                completion(.failure(error))
+                return
+            }
+            
+            let seed = weekOfYear + (year * 100)
+            let index = seed % documents.count
+            let selectedDoc = documents[index]
+            
+            if let event = EventFactory.createEvent(from: selectedDoc) {
+                completion(.success(event))
+            } else {
+                let error = NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to parse event"])
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    private func getCurrentTimeOfDay() -> String {
+        let hour = Calendar.current.component(.hour, from: Date())
+        
+        switch hour {
+        case 6..<12: return "morning"
+        case 12..<17: return "afternoon"
+        case 17..<21: return "evening"
+        default: return "night"
+        }
+    }
+}

--- a/Swifties/Services/WeeklyChallengeStorageService.swift
+++ b/Swifties/Services/WeeklyChallengeStorageService.swift
@@ -1,0 +1,183 @@
+//
+//  WeeklyChallengeStorageService.swift
+//  Swifties
+//
+//  Layer 2: Realm Storage for Weekly Challenge
+//
+
+import Foundation
+import RealmSwift
+
+class WeeklyChallengeStorageService {
+    static let shared = WeeklyChallengeStorageService()
+    
+    private var realm: Realm?
+    private let storageExpirationHours: Double = 24.0 // 24 hours
+    
+    private init() {
+        setupRealm()
+    }
+    
+    private func setupRealm() {
+        do {
+            let config = Realm.Configuration(
+                schemaVersion: 1,
+                migrationBlock: { migration, oldSchemaVersion in
+                    if oldSchemaVersion < 1 {
+                        // Handle migrations if needed
+                    }
+                }
+            )
+            
+            Realm.Configuration.defaultConfiguration = config
+            realm = try Realm()
+            print("✅ Realm initialized for Weekly Challenge")
+        } catch {
+            print("❌ Error initializing Realm: \(error.localizedDescription)")
+        }
+    }
+    
+    // MARK: - Save to Realm
+    
+    func saveChallenge(userId: String, event: Event?, hasAttended: Bool, totalChallenges: Int, chartData: [WeeklyChallengeChartData]) {
+        guard let realm = realm else {
+            print("❌ Realm not initialized")
+            return
+        }
+        
+        let weekId = Date().weekIdentifier()
+        
+        // Serialize Event
+        var eventData: Data?
+        if let event = event {
+            let codableEvent = event.toCodable()
+            eventData = try? JSONEncoder().encode(codableEvent)
+        }
+        
+        let realmData = RealmWeeklyChallengeData(
+            userId: userId,
+            weekIdentifier: weekId,
+            eventData: eventData,
+            hasAttended: hasAttended,
+            totalChallenges: totalChallenges,
+            chartData: chartData
+        )
+        
+        do {
+            try realm.write {
+                realm.add(realmData, update: .modified)
+            }
+            print("💾 Saved to Realm: \(userId)_\(weekId)")
+        } catch {
+            print("❌ Error saving to Realm: \(error.localizedDescription)")
+        }
+    }
+    
+    // MARK: - Load from Realm
+    
+    func loadChallenge(userId: String) -> (event: Event?, hasAttended: Bool, totalChallenges: Int, chartData: [WeeklyChallengeChartData])? {
+        guard let realm = realm else {
+            print("❌ Realm not initialized")
+            return nil
+        }
+        
+        let weekId = Date().weekIdentifier()
+        
+        guard let realmData = realm.object(ofType: RealmWeeklyChallengeData.self, forPrimaryKey: userId) else {
+            print("❌ No data found in Realm for: \(userId)")
+            return nil
+        }
+        
+        // Check if data is for current week
+        if realmData.weekIdentifier != weekId {
+            print("⚠️ Stored data is from a different week: \(realmData.weekIdentifier)")
+            deleteChallenge(userId: userId)
+            return nil
+        }
+        
+        // Check expiration
+        let hoursElapsed = Date().timeIntervalSince(realmData.lastUpdated) / 3600
+        print("📦 Realm data age: \(String(format: "%.1f", hoursElapsed)) hours")
+        
+        if hoursElapsed > storageExpirationHours {
+            print("⏰ Realm data expired")
+            deleteChallenge(userId: userId)
+            return nil
+        }
+        
+        // Deserialize Event
+        var event: Event?
+        if let eventData = realmData.eventData {
+            if let codableEvent = try? JSONDecoder().decode(CodableEvent.self, from: eventData) {
+                event = Event.from(codable: codableEvent)
+            }
+        }
+        
+        // Convert Realm List to Array
+        let chartData = Array(realmData.chartData.map { WeeklyChallengeChartData(label: $0.label, count: $0.count) })
+        
+        print("✅ Loaded from Realm: \(userId)_\(weekId)")
+        return (event: event, hasAttended: realmData.hasAttended, totalChallenges: realmData.totalChallenges, chartData: chartData)
+    }
+    
+    // MARK: - Delete
+    
+    func deleteChallenge(userId: String) {
+        guard let realm = realm else { return }
+        
+        if let object = realm.object(ofType: RealmWeeklyChallengeData.self, forPrimaryKey: userId) {
+            do {
+                try realm.write {
+                    realm.delete(object)
+                }
+                print("🗑️ Deleted from Realm: \(userId)")
+            } catch {
+                print("❌ Error deleting from Realm: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    func clearAllStorage() {
+        guard let realm = realm else { return }
+        
+        do {
+            try realm.write {
+                realm.deleteAll()
+            }
+            print("🗑️ All Realm data cleared")
+        } catch {
+            print("❌ Error clearing Realm: \(error.localizedDescription)")
+        }
+    }
+    
+    // MARK: - Debug
+    
+    func debugStorage(userId: String) {
+        guard let realm = realm else {
+            print("❌ Realm not initialized")
+            return
+        }
+        
+        print("\n=== DEBUG WEEKLY CHALLENGE REALM ===")
+        print("User ID: \(userId)")
+        print("Current Week: \(Date().weekIdentifier())")
+        
+        if let data = realm.object(ofType: RealmWeeklyChallengeData.self, forPrimaryKey: userId) {
+            let hoursElapsed = Date().timeIntervalSince(data.lastUpdated) / 3600
+            print("Found: YES")
+            print("Week ID: \(data.weekIdentifier)")
+            print("Last Updated: \(data.lastUpdated)")
+            print("Age: \(String(format: "%.1f", hoursElapsed)) hours")
+            print("Has Attended: \(data.hasAttended)")
+            print("Total Challenges: \(data.totalChallenges)")
+            print("Chart Data Points: \(data.chartData.count)")
+            print("Event Data Size: \(data.eventData?.count ?? 0) bytes")
+        } else {
+            print("Found: NO")
+        }
+        
+        let allObjects = realm.objects(RealmWeeklyChallengeData.self)
+        print("Total stored users: \(allObjects.count)")
+        print("====================================\n")
+    }
+}

--- a/Swifties/ViewModels/WeeklyChallengeViewModel.swift
+++ b/Swifties/ViewModels/WeeklyChallengeViewModel.swift
@@ -144,7 +144,7 @@ class WeeklyChallengeViewModel: ObservableObject {
                 self.isRefreshing = false
                 
                 if case .success(let data) = result {
-                    // Update data silently (sin cambiar la UI visiblemente)
+                    // Update data silently (without visibly changing the UI)
                     self.challengeEvent = data.event
                     self.hasAttended = data.hasAttended
                     self.totalChallenges = data.totalChallenges

--- a/Swifties/ViewModels/WeeklyChallengeViewModel.swift
+++ b/Swifties/ViewModels/WeeklyChallengeViewModel.swift
@@ -149,7 +149,7 @@ class WeeklyChallengeViewModel: ObservableObject {
                     self.hasAttended = data.hasAttended
                     self.totalChallenges = data.totalChallenges
                     self.last30DaysData = data.chartData
-                    // NO cambiar dataSource - mantener el indicador de caché
+                    // Do NOT change dataSource - keep the cache indicator
                     
                     // Update caches for next time
                     self.cacheService.cacheChallenge(

--- a/Swifties/ViewModels/WeeklyChallengeViewModel.swift
+++ b/Swifties/ViewModels/WeeklyChallengeViewModel.swift
@@ -1,13 +1,6 @@
-//
-//  WeeklyChallengeViewModel.swift
-//  Swifties
-//
-//  Created by Imac  on 4/10/25.
-//
 
 import SwiftUI
 import FirebaseAuth
-import FirebaseFirestore
 import Combine
 
 class WeeklyChallengeViewModel: ObservableObject {
@@ -17,329 +10,223 @@ class WeeklyChallengeViewModel: ObservableObject {
     @Published var hasAttended: Bool = false
     @Published var isLoading = false
     @Published var errorMessage: String?
+    @Published var dataSource: DataSource = .none
+    @Published var isRefreshing = false
     
-    private let db = Firestore.firestore(database: "default")
+    enum DataSource {
+        case none
+        case memoryCache
+        case realmStorage
+        case network
+    }
+    
+    private let cacheService = WeeklyChallengeCacheService.shared
+    private let storageService = WeeklyChallengeStorageService.shared
+    private let networkService = WeeklyChallengeNetworkService.shared
+    private let networkMonitor = NetworkMonitor.shared
+    
     private var currentUserId: String? {
         Auth.auth().currentUser?.uid
     }
     
+    // MARK: - Load Data (Three-Layer Cache)
+    
     func loadChallenge() {
         isLoading = true
         errorMessage = nil
-        hasAttended = false
         
         guard let userId = currentUserId else {
-            errorMessage = "User not authenticated"
             isLoading = false
+            errorMessage = "User not authenticated"
             return
         }
         
         print("🚀 Loading challenge for user: \(userId)")
         
-        let group = DispatchGroup()
-        
-        group.enter()
-        loadRandomEvent { result in
-            switch result {
-            case .success(let event):
-                DispatchQueue.main.async {
-                    self.challengeEvent = event
-                    print("✅ Event loaded: \(event.name)")
-                }
-                group.enter()
-                self.checkIfUserAttended(userId: userId, eventId: event.name) {
-                    group.leave()
-                }
-            case .failure(let error):
-                DispatchQueue.main.async {
-                    self.errorMessage = error.localizedDescription
-                }
-            }
-            group.leave()
+        // Layer 1: Try memory cache
+        if let cached = cacheService.getCachedChallenge(userId: userId) {
+            self.challengeEvent = cached.event
+            self.hasAttended = cached.hasAttended
+            self.totalChallenges = cached.totalChallenges
+            self.last30DaysData = cached.chartData
+            self.dataSource = .memoryCache
+            self.isLoading = false
+            print("✅ Loaded from memory cache")
+            
+            // Try to refresh in background if connected
+            refreshInBackground(userId: userId)
+            return
         }
         
-        group.enter()
-        loadUserChallengeStats(userId: userId) { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(let stats):
-                    self.totalChallenges = stats
-                case .failure(let error):
-                    print("Error loading stats: \(error)")
-                    self.totalChallenges = 0
-                }
-            }
-            group.leave()
+        // Layer 2: Try Realm storage
+        if let stored = storageService.loadChallenge(userId: userId) {
+            self.challengeEvent = stored.event
+            self.hasAttended = stored.hasAttended
+            self.totalChallenges = stored.totalChallenges
+            self.last30DaysData = stored.chartData
+            self.dataSource = .realmStorage
+            self.isLoading = false
+            
+            // Cache in memory for next time
+            cacheService.cacheChallenge(
+                userId: userId,
+                event: stored.event,
+                hasAttended: stored.hasAttended,
+                totalChallenges: stored.totalChallenges,
+                chartData: stored.chartData
+            )
+            
+            print("✅ Loaded from Realm storage")
+            
+            // Try to refresh in background if connected
+            refreshInBackground(userId: userId)
+            return
         }
         
-        group.enter()
-        loadLast30DaysData(userId: userId) { result in
+        // Layer 3: Fetch from network
+        if networkMonitor.isConnected {
+            fetchFromNetwork(userId: userId)
+        } else {
+            isLoading = false
+            errorMessage = "No internet connection and no cached data available"
+            print("❌ No connection and no local data")
+        }
+    }
+    
+    private func fetchFromNetwork(userId: String) {
+        networkService.fetchChallengeData(userId: userId) { [weak self] result in
             DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.isLoading = false
+                
                 switch result {
                 case .success(let data):
-                    self.last30DaysData = data
+                    self.challengeEvent = data.event
+                    self.hasAttended = data.hasAttended
+                    self.totalChallenges = data.totalChallenges
+                    self.last30DaysData = data.chartData
+                    self.dataSource = .network
+                    
+                    // Save to both cache layers
+                    self.cacheService.cacheChallenge(
+                        userId: userId,
+                        event: data.event,
+                        hasAttended: data.hasAttended,
+                        totalChallenges: data.totalChallenges,
+                        chartData: data.chartData
+                    )
+                    
+                    self.storageService.saveChallenge(
+                        userId: userId,
+                        event: data.event,
+                        hasAttended: data.hasAttended,
+                        totalChallenges: data.totalChallenges,
+                        chartData: data.chartData
+                    )
+                    
+                    print("✅ Loaded from network and cached")
+                    
                 case .failure(let error):
-                    print("Error loading chart data: \(error)")
-                    self.last30DaysData = []
+                    self.errorMessage = "Error loading challenge: \(error.localizedDescription)"
+                    print("❌ Network error: \(error.localizedDescription)")
                 }
             }
-            group.leave()
-        }
-        
-        group.notify(queue: .main) {
-            self.isLoading = false
-            print("✅ Challenge loading completed. hasAttended: \(self.hasAttended)")
         }
     }
+    
+    private func refreshInBackground(userId: String) {
+        guard networkMonitor.isConnected else { return }
+        
+        self.isRefreshing = true
+        networkService.fetchChallengeData(userId: userId) { [weak self] result in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.isRefreshing = false
+                
+                if case .success(let data) = result {
+                    // Update data silently (sin cambiar la UI visiblemente)
+                    self.challengeEvent = data.event
+                    self.hasAttended = data.hasAttended
+                    self.totalChallenges = data.totalChallenges
+                    self.last30DaysData = data.chartData
+                    // NO cambiar dataSource - mantener el indicador de caché
+                    
+                    // Update caches for next time
+                    self.cacheService.cacheChallenge(
+                        userId: userId,
+                        event: data.event,
+                        hasAttended: data.hasAttended,
+                        totalChallenges: data.totalChallenges,
+                        chartData: data.chartData
+                    )
+                    
+                    self.storageService.saveChallenge(
+                        userId: userId,
+                        event: data.event,
+                        hasAttended: data.hasAttended,
+                        totalChallenges: data.totalChallenges,
+                        chartData: data.chartData
+                    )
+                    
+                    print("✅ Updated in background (dataSource unchanged)")
+                }
+            }
+        }
+    }
+    
+    // MARK: - Mark as Attending
     
     func markAsAttending() {
-        guard let userId = currentUserId,
-              let event = challengeEvent else {
-            print("Error: No user or event available")
+        guard let userId = currentUserId, let event = challengeEvent else {
+            print("❌ No user or event available")
             return
         }
         
-        print("🔵 Saving activity for user: \(userId), event: \(event.name)")
+        print("🔵 Marking as attending...")
         
-        let activityData: [String: Any] = [
-            "event_id": event.name,
-            "source": "weekly_challenge",
-            "time": Timestamp(date: Date()),
-            "time_of_day": getCurrentTimeOfDay(),
-            "type": "weekly_challenge",
-            "user_id": userId,
-            "with_friends": false
-        ]
-        
-        print("🔵 Activity data: \(activityData)")
-        
-        db.collection("user_activities").addDocument(data: activityData) { [weak self] error in
-            guard let self = self else { return }
-            
-            if let error = error {
-                print("❌ Error saving activity: \(error.localizedDescription)")
-                DispatchQueue.main.async {
-                    self.errorMessage = "Error saving activity: \(error.localizedDescription)"
-                }
-            } else {
-                print("✅ Activity saved successfully!")
-                AnalyticsService.shared.logCheckIn(activityId: event.name, category: event.category)
-                self.updateUserLastEvent(userId: userId, eventName: event.name)
-            }
-        }
-    }
-
-    private func updateUserLastEvent(userId: String, eventName: String) {
-        let userRef = db.collection("users").document(userId)
-        
-        guard let event = challengeEvent else {
-            print("❌ Error: No event available")
-            return
-        }
-        
-        userRef.updateData([
-            "last_event": eventName,
-            "last_event_time": Timestamp(date: Date()),
-            "event_last_category": event.category
-        ]) { [weak self] error in
-            guard let self = self else { return }
-            
+        networkService.markAsAttending(userId: userId, event: event) { [weak self] result in
             DispatchQueue.main.async {
-                if let error = error {
-                    print("❌ Error updating last_event: \(error.localizedDescription)")
-                    self.errorMessage = "Error updating user profile: \(error.localizedDescription)"
-                } else {
-                    print("✅ User's last_event updated to: \(eventName), category: \(event.category)")
-                    self.hasAttended = true
-                    self.totalChallenges += 1
-                    self.loadChallenge()
-                }
-            }
-        }
-    }
-    
-    private func checkIfUserAttended(userId: String, eventId: String, completion: @escaping () -> Void) {
-        print("🔍 Checking attendance for user: \(userId), event: \(eventId)")
-        
-        db.collection("user_activities")
-            .whereField("user_id", isEqualTo: userId)
-            .whereField("event_id", isEqualTo: eventId)
-            .whereField("type", isEqualTo: "weekly_challenge")
-            .getDocuments { [weak self] snapshot, error in
-                guard let self = self else {
-                    completion()
-                    return
-                }
-                
-                if let error = error {
-                    print("❌ Error checking attendance: \(error.localizedDescription)")
-                    DispatchQueue.main.async {
-                        self.hasAttended = false
-                    }
-                    completion()
-                    return
-                }
-                
-                let documentsCount = snapshot?.documents.count ?? 0
-                let attended = documentsCount > 0
-                
-                print("📊 Documents found for this event: \(documentsCount)")
-                print(attended ? "✅ User HAS attended this event" : "❌ User has NOT attended this event")
-                
-                DispatchQueue.main.async {
-                    self.hasAttended = attended
-                    print("🔄 Updated hasAttended to: \(self.hasAttended)")
-                }
-                completion()
-            }
-    }
-    
-    private func loadUserChallengeStats(userId: String, completion: @escaping (Result<Int, Error>) -> Void) {
-        print("📊 Loading user challenge stats for: \(userId)")
-        
-        db.collection("user_activities")
-            .whereField("user_id", isEqualTo: userId)
-            .whereField("type", isEqualTo: "weekly_challenge")
-            .getDocuments { snapshot, error in
-                if let error = error {
-                    print("❌ Error loading stats: \(error.localizedDescription)")
-                    completion(.failure(error))
-                    return
-                }
-                
-                let count = snapshot?.documents.count ?? 0
-                print("✅ Total challenges found: \(count)")
-                completion(.success(count))
-            }
-    }
-    
-    private func loadLast30DaysData(userId: String, completion: @escaping (Result<[WeeklyChallengeChartData], Error>) -> Void) {
-        var calendar = Calendar.current
-        calendar.firstWeekday = 2
-        
-        let currentDate = Date()
-        
-        guard calendar.date(byAdding: .day, value: -30, to: currentDate) != nil else {
-            let error = NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Error calculating date"])
-            completion(.failure(error))
-            return
-        }
-        
-        print("📊 Loading activities from last 30 days")
-        
-        db.collection("user_activities")
-            .whereField("user_id", isEqualTo: userId)
-            .whereField("type", isEqualTo: "weekly_challenge")
-            .getDocuments { [weak self] snapshot, error in
                 guard let self = self else { return }
                 
-                if let error = error {
-                    print("❌ Error loading activities: \(error.localizedDescription)")
-                    completion(.failure(error))
-                    return
+                switch result {
+                case .success():
+                    print("✅ Successfully marked as attending")
+                    AnalyticsService.shared.logCheckIn(activityId: event.name, category: event.category)
+                    
+                    // Clear cache and reload to get fresh data
+                    self.forceRefresh()
+                    
+                case .failure(let error):
+                    self.errorMessage = "Error saving activity: \(error.localizedDescription)"
+                    print("❌ Error: \(error.localizedDescription)")
                 }
-                
-                let dateFormatter = DateFormatter()
-                dateFormatter.dateFormat = "MMM dd, yyyy HH:mm"
-                dateFormatter.timeZone = calendar.timeZone
-                
-                var activityDates: [Date] = []
-                if let documents = snapshot?.documents {
-                    print("📄 Found \(documents.count) total activities in last 30 days:")
-                    for doc in documents {
-                        let data = doc.data()
-                        if let timestamp = data["time"] as? Timestamp {
-                            let activityDate = timestamp.dateValue()
-                            activityDates.append(activityDate)
-                            print("   - \(dateFormatter.string(from: activityDate)) - Event: \(data["event_id"] ?? "Unknown")")
-                        }
-                    }
-                }
-                
-                var chartData: [WeeklyChallengeChartData] = []
-                var hasAttendedThisWeek = false
-                
-                for i in 0..<4 {
-                    let weeksAgo = 3 - i
-                    let targetDate = calendar.date(byAdding: .weekOfYear, value: -weeksAgo, to: currentDate) ?? currentDate
-                    
-                    guard let weekInterval = calendar.dateInterval(of: .weekOfYear, for: targetDate) else {
-                        continue
-                    }
-                    
-                    let startOfWeek = weekInterval.start
-                    let endOfWeek = weekInterval.end
-                    let label = weeksAgo == 0 ? "This Week" : "\(weeksAgo)w ago"
-                    
-                    let activitiesInWeek = activityDates.filter { activityDate in
-                        activityDate >= startOfWeek && activityDate < endOfWeek
-                    }
-                    
-                    let hasCompleted = !activitiesInWeek.isEmpty
-                    chartData.append(WeeklyChallengeChartData(label: label, count: hasCompleted ? 1 : 0))
-                    
-                    if weeksAgo == 0 {
-                        hasAttendedThisWeek = hasCompleted
-                    }
-                }
-                
-                DispatchQueue.main.async {
-                    self.hasAttended = hasAttendedThisWeek
-                    print("🔄 Final hasAttended: \(self.hasAttended)")
-                }
-                
-                completion(.success(chartData))
-            }
-    }
-    
-    // ✅ CAMBIO PRINCIPAL: Esta función ahora usa EventFactory
-    private func loadRandomEvent(completion: @escaping (Result<Event, Error>) -> Void) {
-        var calendar = Calendar.current
-        calendar.firstWeekday = 2
-        
-        let weekOfYear = calendar.component(.weekOfYear, from: Date())
-        let year = calendar.component(.year, from: Date())
-        
-        db.collection("events").getDocuments { snapshot, error in
-            if let error = error {
-                completion(.failure(error))
-                return
-            }
-            
-            guard let documents = snapshot?.documents, !documents.isEmpty else {
-                let error = NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "No events available"])
-                completion(.failure(error))
-                return
-            }
-            
-            let seed = weekOfYear + (year * 100)
-            let index = seed % documents.count
-            let selectedDoc = documents[index]
-            
-            // 🎯 HERE WE USE THE FACTORY - Replaces the 80+ lines of parseEvent
-            if let event = EventFactory.createEvent(from: selectedDoc) {
-                completion(.success(event))
-            } else {
-                let error = NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to parse event"])
-                completion(.failure(error))
             }
         }
     }
     
-    private func getCurrentTimeOfDay() -> String {
-        let hour = Calendar.current.component(.hour, from: Date())
-        
-        switch hour {
-        case 6..<12:
-            return "morning"
-        case 12..<17:
-            return "afternoon"
-        case 17..<21:
-            return "evening"
-        default:
-            return "night"
-        }
+    // MARK: - Cache Management
+    
+    func forceRefresh() {
+        guard let userId = currentUserId else { return }
+        cacheService.clearCache(userId: userId)
+        storageService.deleteChallenge(userId: userId)
+        loadChallenge()
     }
     
-
+    func clearAllCache() {
+        guard let userId = currentUserId else { return }
+        cacheService.clearCache(userId: userId)
+        storageService.deleteChallenge(userId: userId)
+        challengeEvent = nil
+        hasAttended = false
+        totalChallenges = 0
+        last30DaysData = []
+        dataSource = .none
+    }
+    
+    func debugCache() {
+        guard let userId = currentUserId else { return }
+        cacheService.debugCache(userId: userId)
+        storageService.debugStorage(userId: userId)
+    }
 }

--- a/Swifties/Views/WeeklyChallengeView.swift
+++ b/Swifties/Views/WeeklyChallengeView.swift
@@ -414,7 +414,7 @@ struct WeeklyChallengeView: View {
         .onAppear {
             if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" {
                 viewModel.debugCache()
-                // SIEMPRE intentar cargar (usa caché si está disponible)
+                // Always try to load (uses cache if available)
                 viewModel.loadChallenge()
             }
         }

--- a/Swifties/Views/WeeklyChallengeView.swift
+++ b/Swifties/Views/WeeklyChallengeView.swift
@@ -10,6 +10,34 @@ struct WeeklyChallengeView: View {
     @StateObject private var networkMonitor = NetworkMonitor.shared
     private let offlineMessage = "No network connection - Cannot load progress"
     
+    // MARK: - Computed Properties for Data Source Indicator
+    private var dataSourceIcon: String {
+        switch viewModel.dataSource {
+        case .memoryCache: return "memorychip"
+        case .realmStorage: return "internaldrive"
+        case .network: return "wifi"
+        case .none: return "questionmark"
+        }
+    }
+    
+    private var dataSourceText: String {
+        switch viewModel.dataSource {
+        case .memoryCache: return "Memory Cache"
+        case .realmStorage: return "Realm Storage"
+        case .network: return "Updated from Network"
+        case .none: return ""
+        }
+    }
+    
+    private var dataSourceColor: Color {
+        switch viewModel.dataSource {
+        case .memoryCache: return .purple
+        case .realmStorage: return .blue
+        case .network: return .green
+        case .none: return .secondary
+        }
+    }
+    
     var body: some View {
         ZStack {
             Color("appPrimary").ignoresSafeArea()
@@ -27,12 +55,45 @@ struct WeeklyChallengeView: View {
                     dismiss()
                 })
                 
-                if !networkMonitor.isConnected {
+                // Data Source Indicator (NEW)
+                if !viewModel.isLoading && viewModel.challengeEvent != nil {
+                    HStack {
+                        Image(systemName: dataSourceIcon)
+                            .foregroundColor(dataSourceColor)
+                        Text(dataSourceText)
+                            .font(.caption)
+                            .foregroundColor(dataSourceColor)
+                        
+                        if viewModel.isRefreshing {
+                            ProgressView()
+                                .scaleEffect(0.7)
+                            Text("Updating...")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        }
+                        
+                        Spacer()
+                        
+                        // Debug button (optional, remove in production)
+                        Button(action: {
+                            viewModel.debugCache()
+                        }) {
+                            Image(systemName: "ladybug")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .padding(.horizontal)
+                    .padding(.vertical, 8)
+                    .background(Color(.systemBackground).opacity(0.8))
+                }
+                
+                if !networkMonitor.isConnected && viewModel.challengeEvent == nil && !viewModel.isLoading {
                     VStack(spacing: 8) {
                         HStack(spacing: 8) {
                             Image(systemName: "wifi.exclamationmark")
                                 .foregroundColor(.orange)
-                            Text(offlineMessage)
+                            Text("No internet connection")
                                 .font(.subheadline)
                                 .foregroundColor(.orange)
                                 .multilineTextAlignment(.leading)
@@ -40,9 +101,7 @@ struct WeeklyChallengeView: View {
                         }
                         HStack {
                             Button("Retry") {
-                                if networkMonitor.isConnected {
-                                    viewModel.loadChallenge()
-                                }
+                                viewModel.loadChallenge()
                             }
                             .buttonStyle(.borderedProminent)
                             .tint(.orange)
@@ -67,6 +126,15 @@ struct WeeklyChallengeView: View {
                             .foregroundColor(.red)
                             .multilineTextAlignment(.center)
                             .padding()
+                        
+                        // Retry button
+                        Button("Retry") {
+                            viewModel.loadChallenge()
+                        }
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
                     }
                     Spacer()
                 } else {
@@ -345,11 +413,9 @@ struct WeeklyChallengeView: View {
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" {
-                if networkMonitor.isConnected {
-                    viewModel.loadChallenge()
-                } else {
-                    viewModel.errorMessage = offlineMessage
-                }
+                viewModel.debugCache()
+                // SIEMPRE intentar cargar (usa caché si está disponible)
+                viewModel.loadChallenge()
             }
         }
     }


### PR DESCRIPTION
This pull request introduces RealmSwift as a new dependency and implements a new caching layer for weekly challenge data, along with refactoring and enhancements to the models and storage services. The most significant changes are the addition of RealmSwift to the project, new Realm-backed models for weekly challenge data, a new in-memory cache service, and a refactor of user event storage to use UserDefaults instead of SQLite.

**Dependency and Project Configuration Updates:**

* Added `RealmSwift` as a Swift package dependency to the project, including updates to `Swifties.xcodeproj/project.pbxproj` and `Package.resolved` to support Realm-based persistence. 

**Weekly Challenge Data Modeling and Caching:**

* Created new Realm models (`RealmWeeklyChallengeData`, `RealmChartData`) and conversion logic to support persistent storage and cache of weekly challenge data. Also added a helper for week identification and a cache model for in-memory operations in `WeeklyChallengeModels.swift`.
* Added `WeeklyChallengeCacheService`, an in-memory cache layer for weekly challenge data, supporting cache get/set/clear operations and debugging.

**Model Improvements:**

* Updated `WeeklyChallengeChartData` to conform to `Codable` and improved its initializers for better compatibility with Realm and cache operations.

**User Event Storage Refactor:**

* Refactored `UserEventStorageService` to use `UserDefaults` with JSON encoding/decoding for storing user events and free time slots, replacing the previous SQLite-based approach. Added new methods for debugging and calculating storage size, and introduced a `CodableFreeTimeSlot` struct for simplified serialization.