### PR TITLE
Analytics Requested Directions

### DIFF
--- a/Swifties/Services/AnalyticsService.swift
+++ b/Swifties/Services/AnalyticsService.swift
@@ -61,7 +61,7 @@ class AnalyticsService {
         ])
     }
     
-    // Log cuando el usuario solicita direcciones a un evento
+    // Log when the user requests directions to an event
     func logDirectionRequest(eventId: String, eventName: String) {
         Analytics.logEvent("event_direction_requested", parameters: [
             "event_id": eventId,

--- a/Swifties/Services/AnalyticsService.swift
+++ b/Swifties/Services/AnalyticsService.swift
@@ -47,8 +47,6 @@ class AnalyticsService {
         Analytics.setUserID(userId)
     }
 
-
-
     func logError(_ error: Error, platform: String) {
         Analytics.logEvent("app_exception", parameters: [
             "error_type": String(describing: type(of: error)),
@@ -62,7 +60,18 @@ class AnalyticsService {
             "category": category
         ])
     }
+    
+    // Log cuando el usuario solicita direcciones a un evento
+    func logDirectionRequest(eventId: String, eventName: String) {
+        Analytics.logEvent("event_direction_requested", parameters: [
+            "event_id": eventId,
+            "event_name": eventName,
+            "timestamp": Date().timeIntervalSince1970
+        ])
+        print("📍 Analytics: Direction requested for event: \(eventName)")
+    }
 }
+
 func activarFirebase() {
     Analytics.setAnalyticsCollectionEnabled(true)
 }

--- a/Swifties/Services/AnalyticsService.swift
+++ b/Swifties/Services/AnalyticsService.swift
@@ -68,7 +68,7 @@ class AnalyticsService {
             "event_name": eventName,
             "timestamp": Date().timeIntervalSince1970
         ])
-        print("📍 Analytics: Direction requested for event: \(eventName)")
+        // Debug print removed for production consistency
     }
 }
 

--- a/Swifties/Views/EventMapView.swift
+++ b/Swifties/Views/EventMapView.swift
@@ -334,7 +334,7 @@ struct NearbyEventRow: View {
             
             Spacer()
             
-            // Botón de direcciones
+            // Direction button
             Button(action: onDirectionTap) {
                 Image(systemName: "arrow.triangle.turn.up.right.circle.fill")
                     .font(.system(size: 28))

--- a/Swifties/Views/EventMapView.swift
+++ b/Swifties/Views/EventMapView.swift
@@ -84,7 +84,7 @@ struct EventMapView: View {
         print("✅ AnalyticsService.logDirectionRequest called successfully")
         
         mapItem.openInMaps(launchOptions: [
-            MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDriving
+            MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeWalking
         ])
         
         print("🚗 Apple Maps opened")

--- a/Swifties/Views/EventMapView.swift
+++ b/Swifties/Views/EventMapView.swift
@@ -70,7 +70,7 @@ struct EventMapView: View {
         let mapItem = MKMapItem(placemark: placemark)
         mapItem.name = event.name
         
-        // Log analytics cuando se solicita direcciones
+        // Log analytics when directions are requested
         print("📊 About to call AnalyticsService.logDirectionRequest")
         let eventIdToLog = event.id ?? "unknown"
         print("   - Event ID: \(eventIdToLog)")

--- a/Swifties/Views/EventMapView.swift
+++ b/Swifties/Views/EventMapView.swift
@@ -54,7 +54,7 @@ struct EventMapView: View {
         return Array(withDistance.prefix(count).map { ($0, $1) })
     }
     
-    // Función para abrir direcciones en Apple Maps
+    // Function to open directions in Apple Maps
     private func openDirections(to event: Event) {
         print("🔵 [DEBUG] openDirections called for event: \(event.name)")
         


### PR DESCRIPTION
This pull request adds a new feature that allows users to request directions to an event from the nearby events list, opening Apple Maps and logging the action to analytics. It refactors the UI to include a dedicated directions button for each event and introduces a corresponding analytics event for tracking these requests.

**Feature: Directions Request & Analytics Logging**
* Added `logDirectionRequest(eventId:eventName:)` to `AnalyticsService` to log when users request directions to an event, including event ID, name, and timestamp.
* Integrated analytics logging into the new `openDirections(to:)` method in `EventMapView`, which opens Apple Maps for the selected event and logs the action.

**UI/UX: Directions Button in Nearby Events**
* Updated `NearbyEventRow` to include a new directions button (`arrow.triangle.turn.up.right.circle.fill`) for each event, allowing users to request directions directly.
* Modified `NearbyEventsSheet` and related view logic to support the new `onDirectionRequest` callback, wiring up the directions button to trigger the map opening and analytics logging. [[1]](diffhunk://#diff-b61ad57664e52491990487c8d0a2c4be74a7650275720fd50029523f7960c358R218) [[2]](diffhunk://#diff-b61ad57664e52491990487c8d0a2c4be74a7650275720fd50029523f7960c358R261-R263) [[3]](diffhunk://#diff-b61ad57664e52491990487c8d0a2c4be74a7650275720fd50029523f7960c358R279-L241) [[4]](diffhunk://#diff-b61ad57664e52491990487c8d0a2c4be74a7650275720fd50029523f7960c358L253-R294)

These changes improve user experience by making it easier to get directions to events and enhance analytics tracking for this user action.