### PR TITLE
Changes to protect the email validation view

### DIFF
--- a/Swifties/Views/VerifyEmailView.swift
+++ b/Swifties/Views/VerifyEmailView.swift
@@ -10,6 +10,7 @@ import Combine
 
 struct VerifyEmailView: View {
     @EnvironmentObject var viewModel: AuthViewModel
+    @StateObject private var networkMonitor = NetworkMonitorService.shared
     
     var body: some View {
         ZStack {
@@ -17,6 +18,24 @@ struct VerifyEmailView: View {
                 .ignoresSafeArea()
             
             VStack(spacing: 20) {
+                // Floating connection status banner at the top
+                if !networkMonitor.isConnected {
+                    VStack {
+                        HStack(spacing: 8) {
+                            Image(systemName: "wifi.slash")
+                                .foregroundColor(.red)
+                            Text("No Internet Connection")
+                                .font(.callout)
+                                .foregroundColor(.red)
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(Color.red.opacity(0.1))
+                        .cornerRadius(8)
+                        .padding(.top, 8)
+                    }
+                }
+                
                 Spacer().frame(height: 40)
 
                 Text("Verify your email")
@@ -40,6 +59,7 @@ struct VerifyEmailView: View {
                 ResendEmailButton()
                     .environmentObject(viewModel)
                     .padding(.horizontal, 20)
+                    .disabled(!networkMonitor.isConnected)
 
                 Button {
                     Task { await viewModel.logout() }
@@ -59,6 +79,7 @@ struct VerifyEmailView: View {
                     .frame(maxWidth: .infinity)
                     .background(.appRed)
                     .cornerRadius(12)
+                    .disabled(!networkMonitor.isConnected)
                 }
                 .padding(.horizontal, 20)
 


### PR DESCRIPTION
This pull request improves the user experience in the `VerifyEmailView` by adding network connectivity awareness. The main changes ensure that users are notified when there is no internet connection and prevent them from performing actions that require connectivity.

Network connectivity awareness:

* Added a floating banner to the top of `VerifyEmailView` to notify users when there is no internet connection.
* Disabled the `ResendEmailButton` and the logout button when the device is offline, preventing actions that require internet access. [[1]](diffhunk://#diff-190e204d9d2d45c0af63b13d57be34bb46d52f910aced6a1a3f124004fbee834R62) [[2]](diffhunk://#diff-190e204d9d2d45c0af63b13d57be34bb46d52f910aced6a1a3f124004fbee834R82)
* Integrated `NetworkMonitorService` as a `@StateObject` to observe and react to network status changes in the view.