### PR TITLE
Protect and add messages to the views when there is no connection

### DIFF
--- a/Swifties/Views/EventListView.swift
+++ b/Swifties/Views/EventListView.swift
@@ -52,7 +52,7 @@ struct EventListView: View {
                     })
                     
                     // Connection status indicator
-                    if !networkMonitor.isConnected {
+                    if !networkMonitor.isConnected && !isMapView {
                         HStack(spacing: 8) {
                             Image(systemName: "wifi.slash")
                                 .foregroundColor(.red)
@@ -69,7 +69,7 @@ struct EventListView: View {
                     }
                     
                     // Data Source Indicator
-                    if !viewModel.isLoading && !viewModel.events.isEmpty {
+                    if !viewModel.isLoading && !viewModel.events.isEmpty && !isMapView {
                         HStack {
                             Image(systemName: dataSourceIcon)
                                 .foregroundColor(.secondary)

--- a/Swifties/Views/EventListView.swift
+++ b/Swifties/Views/EventListView.swift
@@ -7,6 +7,7 @@ struct EventListView: View {
     @StateObject var viewModel: EventListViewModel
     @State private var searchText = ""
     @State private var isMapView = false
+    @ObservedObject private var networkMonitor = NetworkMonitorService.shared
 
     // Filter events by search
     var filteredEvents: [Event] {
@@ -21,7 +22,7 @@ struct EventListView: View {
         }
     }
     
-    // MARK: - Computed Properties for Data Source (MOVIDAS AQUÍ)
+    // MARK: - Computed Properties for Data Source
     private var dataSourceIcon: String {
         switch viewModel.dataSource {
         case .memoryCache: return "memorychip"
@@ -49,6 +50,23 @@ struct EventListView: View {
                     CustomTopBar(title: "Events", showNotificationButton: true, onBackTap:  {
                         print("Notification tapped")
                     })
+                    
+                    // Connection status indicator
+                    if !networkMonitor.isConnected {
+                        HStack(spacing: 8) {
+                            Image(systemName: "wifi.slash")
+                                .foregroundColor(.red)
+                            Text("No Internet Connection")
+                                .font(.callout)
+                                .foregroundColor(.red)
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(Color.red.opacity(0.1))
+                        .cornerRadius(8)
+                        .padding(.horizontal)
+                        .padding(.top, 4)
+                    }
                     
                     // Data Source Indicator
                     if !viewModel.isLoading && !viewModel.events.isEmpty {

--- a/Swifties/Views/EventMapView.swift
+++ b/Swifties/Views/EventMapView.swift
@@ -1,5 +1,15 @@
+//
+//  EventMapView.swift
+//  Swifties
+//
+//
+
 import SwiftUI
 import MapKit
+import Network
+
+/// The geographic coordinates for Bogotá, Colombia.
+private let bogotaCoordinates = CLLocationCoordinate2D(latitude: 4.6533, longitude: -74.0836)
 
 struct EventMapView: View {
     let events: [Event]
@@ -7,27 +17,32 @@ struct EventMapView: View {
     var onSelect: ((Event) -> Void)?
     
     @StateObject private var locationManager = LocationManager()
-    @StateObject private var networkMonitor = NetworkMonitorService.shared
-    @State private var region = MKCoordinateRegion(
-        center: CLLocationCoordinate2D(latitude: 4.6533, longitude: -74.0836),
-        span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
-    )
+    @State private var region = MKCoordinateRegion(center: bogotaCoordinates,
+                                                   span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1))
     @State private var showNearbyEvents = false
-    @State private var mapLoadFailed = false
-    @State private var mapLoadTimer: Timer?
     @Environment(\.dismiss) var dismiss
 
+    @StateObject private var networkMonitor = NetworkMonitorService.shared
+    private var offlineMessage: String {
+        validEvents.isEmpty
+            ? "No network connection - Cannot load map view"
+            : "No network connection - Showing cached version"
+    }
+    
+    // Filter events with valid coordinates
     private var validEvents: [Event] {
         events.filter { event in
             guard let coords = event.location?.coordinates,
                   coords.count == 2,
                   coords[0] != 0 || coords[1] != 0 else {
+                print("Invalid coordinates for event: \(event.name)")
                 return false
             }
             return true
         }
     }
     
+    // Calculate nearest N events using Haversine distance
     private func nearestEvents(from location: CLLocation?, count: Int) -> [(event: Event, distance: CLLocationDistance)] {
         guard let location = location else {
             return validEvents.prefix(count).map { ($0, 0) }
@@ -43,114 +58,99 @@ struct EventMapView: View {
         return Array(withDistance.prefix(count).map { ($0, $1) })
     }
     
+    // Function to open directions in Apple Maps
     private func openDirections(to event: Event) {
+        print("🔵 [DEBUG] openDirections called for event: \(event.name)")
+        
         guard let coords = event.location?.coordinates, coords.count == 2 else {
             print("❌ Cannot open directions: Invalid coordinates")
             return
         }
+        
+        print("🗺️ Valid coordinates found: \(coords)")
         
         let coordinate = CLLocationCoordinate2D(latitude: coords[0], longitude: coords[1])
         let placemark = MKPlacemark(coordinate: coordinate)
         let mapItem = MKMapItem(placemark: placemark)
         mapItem.name = event.name
         
+        // Log analytics when directions are requested
+        print("📊 About to call AnalyticsService.logDirectionRequest")
+        let eventIdToLog = event.id ?? "unknown"
+        print("   - Event ID: \(eventIdToLog)")
+        print("   - Event Name: \(event.name)")
+        
         AnalyticsService.shared.logDirectionRequest(
-            eventId: event.id ?? "unknown",
+            eventId: eventIdToLog,
             eventName: event.name
         )
+        
+        print("✅ AnalyticsService.logDirectionRequest called successfully")
         
         mapItem.openInMaps(launchOptions: [
             MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeWalking
         ])
+        
+        print("🚗 Apple Maps opened")
     }
     
     var body: some View {
         ZStack(alignment: .top) {
-            if mapLoadFailed {
-                // Plan Z: Map failed to load
-                VStack(spacing: 20) {
-                    Spacer()
-                    
-                    Image(systemName: "map.fill")
-                        .font(.system(size: 60))
-                        .foregroundColor(.gray)
-                    
-                    Text("Map Unavailable")
-                        .font(.title2)
-                        .fontWeight(.bold)
-                    
-                    Text("Unable to load map. Please check your connection and try again.")
-                        .font(.body)
-                        .foregroundColor(.secondary)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 40)
-                    
-                    Button(action: {
-                        mapLoadFailed = false
-                        startMapLoadTimer()
-                    }) {
-                        HStack(spacing: 8) {
-                            Image(systemName: "arrow.clockwise")
-                            Text("Retry")
-                        }
-                        .fontWeight(.semibold)
-                        .foregroundColor(.white)
-                        .padding(.horizontal, 24)
-                        .padding(.vertical, 12)
-                        .background(Color.pink)
-                        .cornerRadius(25)
-                    }
-                    .padding(.top, 8)
-                    
-                    Spacer()
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color(.systemBackground))
-            } else {
-                // Normal map view
-                Map(initialPosition: .region(region)) {
-                    ForEach(validEvents) { event in
-                        if let coords = event.location?.coordinates,
-                           coords.count == 2 {
-                            let coordinate = CLLocationCoordinate2D(latitude: coords[0], longitude: coords[1])
-                            
-                            Annotation(event.title, coordinate: coordinate) {
-                                Button {
-                                    selectedEvent = event
-                                    onSelect?(event)
-                                } label: {
-                                    Image(systemName: "mappin.circle.fill")
-                                        .font(.title)
-                                        .foregroundColor(.pink)
-                                        .shadow(radius: 2)
-                                }
+            // Map
+            Map(initialPosition: .region(region)) {
+                ForEach(validEvents) { event in
+                    if let coords = event.location?.coordinates,
+                       coords.count == 2 {
+                        let coordinate = CLLocationCoordinate2D(latitude: coords[0], longitude: coords[1])
+                        
+                        Annotation(event.title, coordinate: coordinate) {
+                            Button {
+                                selectedEvent = event
+                                onSelect?(event)
+                            } label: {
+                                Image(systemName: "mappin.circle.fill")
+                                    .font(.title)
+                                    .foregroundColor(.pink)
+                                    .shadow(radius: 2)
                             }
                         }
                     }
-                    
-                    if let userLocation = locationManager.lastLocation?.coordinate {
-                        Annotation("You", coordinate: userLocation) {
-                            Circle()
-                                .fill(Color.blue)
-                                .frame(width: 16, height: 16)
-                                .overlay(
-                                    Circle()
-                                        .stroke(Color.white, lineWidth: 3)
-                                )
-                        }
-                    }
-                }
-                .onAppear {
-                    // Cancel timer when map appears successfully
-                    mapLoadTimer?.invalidate()
-                    mapLoadTimer = nil
                 }
                 
+                // User location annotation
+                if let userLocation = locationManager.lastLocation?.coordinate {
+                    Annotation("You", coordinate: userLocation) {
+                        Circle()
+                            .fill(Color.blue)
+                            .frame(width: 16, height: 16)
+                            .overlay(
+                                Circle()
+                                    .stroke(Color.white, lineWidth: 3)
+                            )
+                    }
+                }
+            }
+            
+            if !networkMonitor.isConnected {
+                HStack(spacing: 8) {
+                    Image(systemName: "wifi.slash")
+                        .foregroundColor(.red)
+                    Text(offlineMessage)
+                        .font(.subheadline)
+                        .foregroundColor(.red)
+                        .multilineTextAlignment(.leading)
+                    Spacer()
+                }
+                .padding()
+                .background(Color(.systemBackground))
+                .cornerRadius(12)
+                .padding()
+            } else {
                 // Floating Action Button
                 VStack {
                     Spacer()
                     
-                    if networkMonitor.isConnected && locationManager.lastLocation != nil {
+                    if locationManager.lastLocation != nil {
                         Button(action: {
                             showNearbyEvents = true
                         }) {
@@ -179,14 +179,9 @@ struct EventMapView: View {
                     region.center = userLocation
                     region.span = MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
                 }
+            } else {
+                print(offlineMessage)
             }
-            
-            // Start a timer to detect if map fails to load
-            startMapLoadTimer()
-        }
-        .onDisappear {
-            mapLoadTimer?.invalidate()
-            mapLoadTimer = nil
         }
         .onReceive(locationManager.$lastLocation) { location in
             guard networkMonitor.isConnected, let coord = location?.coordinate else { return }
@@ -219,16 +214,6 @@ struct EventMapView: View {
         }
         .navigationBarHidden(true)
     }
-    
-    private func startMapLoadTimer() {
-        // If map doesn't render within 3 seconds and there's no network, assume failure
-        mapLoadTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: false) { _ in
-            if !networkMonitor.isConnected {
-                mapLoadFailed = true
-                print("⚠️ Map load timeout - no network connection")
-            }
-        }
-    }
 }
 
 struct NearbyEventsSheet: View {
@@ -246,6 +231,7 @@ struct NearbyEventsSheet: View {
     
     var body: some View {
         VStack(spacing: 0) {
+            // Title section
             HStack {
                 Image(systemName: "location.fill")
                     .foregroundColor(Color(red: 0.89, green: 0.58, blue: 0.31))
@@ -266,6 +252,7 @@ struct NearbyEventsSheet: View {
             
             Divider()
             
+            // Events list
             ScrollView {
                 VStack(spacing: 12) {
                     ForEach(Array(nearbyEvents.enumerated()), id: \.element.event.id) { index, item in
@@ -297,6 +284,7 @@ struct NearbyEventRow: View {
     
     var body: some View {
         HStack(spacing: 12) {
+            // Rank badge
             ZStack {
                 Circle()
                     .fill(Color(red: 0.89, green: 0.58, blue: 0.31))
@@ -306,6 +294,7 @@ struct NearbyEventRow: View {
                     .foregroundColor(.white)
             }
             
+            // Event info (tappable)
             Button(action: onTap) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(event.name)
@@ -349,6 +338,7 @@ struct NearbyEventRow: View {
             
             Spacer()
             
+            // Direction button
             Button(action: onDirectionTap) {
                 Image(systemName: "arrow.triangle.turn.up.right.circle.fill")
                     .font(.system(size: 28))
@@ -360,5 +350,11 @@ struct NearbyEventRow: View {
         .background(Color(.systemBackground))
         .cornerRadius(12)
         .shadow(color: .black.opacity(0.05), radius: 4, x: 0, y: 2)
+    }
+}
+
+struct EventMapView_Previews: PreviewProvider {
+    static var previews: some View {
+        EventMapView(events: [], selectedEvent: .constant(nil), onSelect: nil)
     }
 }


### PR DESCRIPTION
Closes #139 

This pull request improves the user experience by adding clearer indicators for network connectivity status in both the event list and map views. It introduces a shared network monitor to the event list, displays a prominent offline warning, and refines the messaging and styling for offline mode in the map view.

**Network connectivity indicators:**

* Added a shared `NetworkMonitorService` as an `@ObservedObject` to `EventListView`, enabling real-time monitoring of internet connection status.
* Displayed a "No Internet Connection" warning with a red icon and styling in `EventListView` when offline and not in map view.

**Offline messaging and styling in map view:**

* Updated `EventMapView` to show a context-sensitive offline message: if there are no cached events, it warns that the map view cannot load; otherwise, it informs the user that a cached version is being shown.
* Changed the offline indicator in `EventMapView` to use a red "wifi.slash" icon and red text for greater visibility and consistency with the event list view.

**Minor code cleanup:**

* Removed an unnecessary comment marker from the computed properties section in `EventListView`.