### PR TITLE
Profile Aesthetic visualization

### DIFF
--- a/Swifties/Services/WishMeLuckStorageService.swift
+++ b/Swifties/Services/WishMeLuckStorageService.swift
@@ -46,7 +46,7 @@ class WishMeLuckStorageService {
     func saveDaysSinceLastWished(userId: String, days: Int, lastWishedDate: Date?) {
         // Realm operations on dedicated queue
         realmQueue.async { [weak self] in
-            guard let self = self else { return }
+            guard let _ = self else { return }
             
             // Get Realm instance on this thread
             guard let realm = try? Realm() else {
@@ -139,7 +139,7 @@ class WishMeLuckStorageService {
     
     func clearAllStorage() {
         realmQueue.async { [weak self] in
-            guard let self = self else { return }
+            guard let _ = self else { return }
             guard let realm = try? Realm() else { return }
             
             do {
@@ -158,7 +158,7 @@ class WishMeLuckStorageService {
     
     func debugStorage(userId: String) {
         realmQueue.async { [weak self] in
-            guard let self = self else { return }
+            guard let _ = self else { return }
             guard let realm = try? Realm() else {
                 print("❌ Realm not initialized")
                 return

--- a/Swifties/ViewModels/AuthViewModel.swift
+++ b/Swifties/ViewModels/AuthViewModel.swift
@@ -61,7 +61,7 @@ class AuthViewModel: ObservableObject {
         networkMonitor.$isConnected
             .removeDuplicates()
             .sink { [weak self] isConnected in
-                guard let self = self, isConnected else { return }
+                guard let _ = self, isConnected else { return }
                 Task { @MainActor in
                     print("🌐 Network restored - attempting to sync pending data...")
                     await RegistrationSyncService.shared.syncPendingRegistration()
@@ -170,7 +170,7 @@ class AuthViewModel: ObservableObject {
     
     // MARK: - Recheck User Status (after sync)
     private func recheckUserStatus() async {
-        guard let uid = user?.uid else { return }
+        guard let _ = user?.uid else { return }
         print("🔄 Rechecking user status after sync...")
         await checkFirstTimeUser()
     }

--- a/Swifties/ViewModels/ProfileViewModel.swift
+++ b/Swifties/ViewModels/ProfileViewModel.swift
@@ -193,6 +193,8 @@ final class ProfileViewModel: ObservableObject {
             self.profile = cached
             self.dataSource = .memoryCache
             self.isLoading = false
+            // Refresh in background if online
+            refreshInBackground()
             return
         }
 
@@ -201,7 +203,7 @@ final class ProfileViewModel: ObservableObject {
             self.profile = stored
             self.dataSource = .localStorage
             self.isLoading = false
-            // refresh in background if online
+            // Refresh in background if online
             refreshInBackground()
             return
         }
@@ -242,6 +244,8 @@ final class ProfileViewModel: ObservableObject {
                 if case .success(let profile) = result {
                     self.cacheService.cacheProfile(profile)
                     self.storageService.saveProfile(profile)
+                    self.profile = profile
+                    self.dataSource = .network
                 }
             }
         }

--- a/Swifties/Views/ProfileView.swift
+++ b/Swifties/Views/ProfileView.swift
@@ -11,6 +11,25 @@ struct ProfileView: View {
     @StateObject private var viewModel = ProfileViewModel()
     @EnvironmentObject var authViewModel: AuthViewModel
     @StateObject private var networkMonitor = NetworkMonitorService.shared
+    
+    // MARK: - Data Source Indicator (matches HomeView)
+    private var dataSourceIcon: String {
+        switch viewModel.dataSource {
+        case .memoryCache: return "memorychip"
+        case .localStorage: return "internaldrive"
+        case .network: return "wifi"
+        case .none: return "questionmark"
+        }
+    }
+    
+    private var dataSourceText: String {
+        switch viewModel.dataSource {
+        case .memoryCache: return "Memory Cache"
+        case .localStorage: return "Local Storage"
+        case .network: return "Updated from Network"
+        case .none: return ""
+        }
+    }
         
     var body: some View {
         
@@ -24,15 +43,38 @@ struct ProfileView: View {
                         print("Notifications tapped")
                     })
                 
+                // Connection status indicator
+                if !networkMonitor.isConnected {
+                    HStack(spacing: 8) {
+                        Image(systemName: "wifi.slash")
+                            .foregroundColor(.red)
+                        Text("No Internet Connection")
+                            .font(.callout)
+                            .foregroundColor(.red)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(Color.red.opacity(0.1))
+                    .cornerRadius(8)
+                    .padding(.horizontal)
+                    .padding(.top, 4)
+                }
+                
+                // Data Source Indicator (matches HomeView)
+                if !viewModel.isLoading, viewModel.profile != nil {
+                    HStack {
+                        Image(systemName: dataSourceIcon)
+                            .foregroundColor(.secondary)
+                        Text(dataSourceText)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.horizontal)
+                    .padding(.top, 8)
+                }
+                
                 ScrollView {
                     VStack(spacing: 25) {
-                        
-                        if !networkMonitor.isConnected {
-                            Text("Offline mode: Showing cached data if available")
-                                .font(.footnote)
-                                .foregroundColor(.yellow)
-                                .padding(.top, 8)
-                        }
                         
                         // Loading / Error / Content States
                         if viewModel.isLoading {


### PR DESCRIPTION
This pull request introduces several improvements to the `ProfileView` and related view models, focusing on enhancing user feedback about data source and connectivity status, as well as minor code cleanups and bug fixes. The most notable changes are the addition of a data source indicator in the profile view, improved offline and network status UI, and ensuring the latest profile data is properly displayed after network refreshes.

**UI/UX Improvements:**

* Added a data source indicator to `ProfileView`, showing whether profile data comes from memory cache, local storage, or the network, with both icon and text [[1]](diffhunk://#diff-3a22c91c72b54f43c75424991fcb5c481af8ae51ed90c7a015fc5a9a960455f1R15-R33) [[2]](diffhunk://#diff-3a22c91c72b54f43c75424991fcb5c481af8ae51ed90c7a015fc5a9a960455f1L27-R78).
* Improved the offline status banner in `ProfileView` to provide clearer feedback when the app is offline.

**Profile Data Handling:**

* Ensured that after a successful network fetch, the profile and its data source are updated immediately in `ProfileViewModel`.
* Triggered a background refresh of the profile when loading from cache or local storage, ensuring data is kept up to date [[1]](diffhunk://#diff-c2ee486c9a4006b9ec7c7fd2e0f2956a87237fcf5fdab8b63f8eac51a63a66efR196-R197) [[2]](diffhunk://#diff-c2ee486c9a4006b9ec7c7fd2e0f2956a87237fcf5fdab8b63f8eac51a63a66efL204-R206).

**Code Quality and Bug Fixes:**

* Standardized the use of `guard let _ = ...` instead of `guard let self = ...` in several asynchronous closures for better clarity and to avoid unused variable warnings [[1]](diffhunk://#diff-f059a7649ad88875fd42cd8fb27bdfce65918966a99f81b1b8b514f75fa8b7adL49-R49) [[2]](diffhunk://#diff-f059a7649ad88875fd42cd8fb27bdfce65918966a99f81b1b8b514f75fa8b7adL142-R142) [[3]](diffhunk://#diff-f059a7649ad88875fd42cd8fb27bdfce65918966a99f81b1b8b514f75fa8b7adL161-R161) [[4]](diffhunk://#diff-99b26b414aef7c73913ce5638b9cbc0261b08691cef14c81a499b34f61949076L64-R64) [[5]](diffhunk://#diff-99b26b414aef7c73913ce5638b9cbc0261b08691cef14c81a499b34f61949076L173-R173).