### PR TITLE
Fix error on offline profile when opening the app again

### DIFF
--- a/Swifties/ViewModels/AuthViewModel.swift
+++ b/Swifties/ViewModels/AuthViewModel.swift
@@ -21,6 +21,7 @@ class AuthViewModel: ObservableObject {
     @Published var isEmailVerified: Bool = false
     @Published var isCheckingProfile: Bool = true
     
+    
     // AuthService singleton
     private let authService = AuthService.shared
     let db = Firestore.firestore(database: "default")
@@ -98,9 +99,12 @@ class AuthViewModel: ObservableObject {
         isCheckingProfile = true
         defer { isCheckingProfile = false }
         
-        // CRITICAL: First check if registration was completed offline
-        if userDefaultsService.hasCompletedRegistrationLocally() {
-            print("✅ Found completed registration in UserDefaults - treating as returning user")
+        print("🔍 Checking first time user status for: \(user.uid)")
+        
+        // CRITICAL FIX: Check BOTH the user-specific AND the global registration flags
+        // First check: Has this specific user completed registration?
+        if userDefaultsService.hasCompletedRegistration(uid: user.uid) {
+            print("✅ Found cached registration status for user \(user.uid) - treating as returning user")
             self.isFirstTimeUser = false
             
             // If we have pending data to sync, try syncing it now
@@ -111,10 +115,19 @@ class AuthViewModel: ObservableObject {
             return
         }
         
-        // Check if we have cached registration status for this user
-        if userDefaultsService.hasCompletedRegistration(uid: user.uid) {
-            print("✅ Found cached registration status for user \(user.uid) - treating as returning user")
+        // Second check: Has ANY registration been completed locally?
+        // This catches the case where the user completed registration offline
+        if userDefaultsService.hasCompletedRegistrationLocally() {
+            print("✅ Found completed registration in UserDefaults - treating as returning user")
+            // IMPORTANT: Also cache this for the specific user
+            userDefaultsService.cacheRegistrationStatus(uid: user.uid, completed: true)
             self.isFirstTimeUser = false
+            
+            // If we have pending data to sync, try syncing it now
+            if userDefaultsService.hasPendingRegistration() && networkMonitor.isConnected {
+                print("🔄 Found pending registration data - attempting to sync...")
+                await RegistrationSyncService.shared.syncPendingRegistration()
+            }
             return
         }
         
@@ -125,7 +138,7 @@ class AuthViewModel: ObservableObject {
                 
                 // User is first-time if document doesn't exist OR doesn't have profile data
                 if !document.exists {
-                    print("📡 First time user - no Firestore document found")
+                    print("First time user - no Firestore document found")
                     isFirstTimeUser = true
                     // Cache this status
                     userDefaultsService.cacheRegistrationStatus(uid: user.uid, completed: false)
@@ -133,13 +146,14 @@ class AuthViewModel: ObservableObject {
                           let profile = data["profile"] as? [String: Any],
                           profile["name"] != nil {
                     // Document exists and has profile data - returning user
-                    print("📡 Returning user - profile found in Firestore")
+                    print("Returning user - profile found in Firestore")
                     isFirstTimeUser = false
                     // IMPORTANT: Cache this status for offline use
                     userDefaultsService.cacheRegistrationStatus(uid: user.uid, completed: true)
+                    userDefaultsService.markRegistrationCompleted()
                 } else {
                     // Document exists but incomplete - treat as first time
-                    print("⚠️ Incomplete profile - treating as first time user")
+                    print("==== Incomplete profile - treating as first time user")
                     isFirstTimeUser = true
                     userDefaultsService.cacheRegistrationStatus(uid: user.uid, completed: false)
                 }
@@ -148,7 +162,7 @@ class AuthViewModel: ObservableObject {
                 
                 // On error while online, check if we have cached status to fall back on
                 if userDefaultsService.hasCompletedRegistration(uid: user.uid) {
-                    print("⚠️ Using cached registration status due to Firestore error")
+                    print("==== Using cached registration status due to Firestore error")
                     isFirstTimeUser = false
                 } else {
                     // No cached data and error - assume first time to be safe
@@ -158,11 +172,11 @@ class AuthViewModel: ObservableObject {
         } else {
             // Offline - check if we have cached status for this specific user
             if userDefaultsService.hasCompletedRegistration(uid: user.uid) {
-                print("📱 Offline - using cached registration status: User has completed registration")
+                print("Offline - using cached registration status: User has completed registration")
                 isFirstTimeUser = false
             } else {
-                print("⚠️ Offline with no cached registration status - treating as first time user")
-                print("⚠️ This can happen after reinstall. User should connect to internet once to verify.")
+                print("=-==== Offline with no cached registration status - treating as first time user")
+                print("-==== This can happen after reinstall. User should connect to internet once to verify.")
                 isFirstTimeUser = true
             }
         }

--- a/Swifties/ViewModels/AuthViewModel.swift
+++ b/Swifties/ViewModels/AuthViewModel.swift
@@ -101,7 +101,7 @@ class AuthViewModel: ObservableObject {
         
         print("🔍 Checking first time user status for: \(user.uid)")
         
-        // CRITICAL FIX: Check BOTH the user-specific AND the global registration flags
+        // Check user-specific registration flag first, then fall back to global registration flag
         // First check: Has this specific user completed registration?
         if userDefaultsService.hasCompletedRegistration(uid: user.uid) {
             print("✅ Found cached registration status for user \(user.uid) - treating as returning user")

--- a/Swifties/Views/EventListView.swift
+++ b/Swifties/Views/EventListView.swift
@@ -44,15 +44,6 @@ struct EventListView: View {
         case .none: return ""
         }
     }
-    
-    private var dataSourceColor: Color {
-        switch viewModel.dataSource {
-        case .memoryCache: return .purple
-        case .localStorage: return .blue
-        case .network: return .green
-        case .none: return .secondary
-        }
-    }
 
     var body: some View {
         NavigationStack {
@@ -64,37 +55,48 @@ struct EventListView: View {
                         print("Notification tapped")
                     })
                     
-                    // Data Source Indicator (enhanced)
+                    // Connection status banner
+                    if !networkMonitor.isConnected {
+                        HStack(spacing: 8) {
+                            Image(systemName: "wifi.slash")
+                                .foregroundColor(.red)
+                            Text("No Internet Connection")
+                                .font(.callout)
+                                .foregroundColor(.red)
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(Color.red.opacity(0.1))
+                        .cornerRadius(8)
+                        .padding(.horizontal)
+                        .padding(.top, 4)
+                    }
+                    
+                    // Data Source Indicator (minimalist gray style)
                     if !viewModel.isLoading && !viewModel.events.isEmpty && !isMapView {
                         HStack {
-                            Image(systemName: dataSourceIcon)
-                                .foregroundColor(dataSourceColor)
-                            Text(dataSourceText)
-                                .font(.caption)
-                                .foregroundColor(dataSourceColor)
+                            Spacer()
                             
-                            if viewModel.isRefreshing {
-                                ProgressView()
-                                    .scaleEffect(0.7)
-                                Text("Updating...")
-                                    .font(.caption2)
+                            HStack(spacing: 6) {
+                                Image(systemName: dataSourceIcon)
                                     .foregroundColor(.secondary)
+                                Text(dataSourceText)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                
+                                if viewModel.isRefreshing {
+                                    ProgressView()
+                                        .scaleEffect(0.7)
+                                    Text("Updating...")
+                                        .font(.caption2)
+                                        .foregroundColor(.secondary)
+                                }
                             }
                             
                             Spacer()
-                            
-                            // Debug button (optional, remove in production)
-                            Button(action: {
-                                EventStorageService.shared.debugStorage()
-                            }) {
-                                Image(systemName: "ladybug")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            }
                         }
                         .padding(.horizontal)
-                        .padding(.vertical, 8)
-                        .background(Color(.systemBackground).opacity(0.8))
+                        .padding(.top, 8)
                     }
 
                     // MARK: - Main Content Area
@@ -270,25 +272,6 @@ struct EventListView: View {
                     }
                 }
                 
-                // Floating connection status banner at the top
-                if !networkMonitor.isConnected && !viewModel.events.isEmpty {
-                    VStack {
-                        HStack(spacing: 8) {
-                            Image(systemName: "wifi.slash")
-                                .foregroundColor(.orange)
-                            Text("Offline - Using cached data")
-                                .font(.caption)
-                                .foregroundColor(.orange)
-                        }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 8)
-                        .background(Color.orange.opacity(0.1))
-                        .cornerRadius(8)
-                        .padding(.top, 60)
-                        
-                        Spacer()
-                    }
-                }
             }
             .alert("Connection Required", isPresented: $showOfflineAlert) {
                 Button("OK", role: .cancel) {}

--- a/Swifties/Views/HomeView.swift
+++ b/Swifties/Views/HomeView.swift
@@ -17,7 +17,7 @@ struct HomeView: View {
     @State private var showOfflineAlert = false
     @State private var offlineAlertMessage = ""
     
-    // MARK: - Computed Properties for Data Source
+    // MARK: - Computed Properties for Data Source Indicator
     private var dataSourceIcon: String {
         switch homeViewModel.dataSource {
         case .memoryCache: return "memorychip"
@@ -35,15 +35,6 @@ struct HomeView: View {
         case .none: return ""
         }
     }
-    
-    private var dataSourceColor: Color {
-        switch homeViewModel.dataSource {
-        case .memoryCache: return .purple
-        case .localStorage: return .blue
-        case .network: return .green
-        case .none: return .secondary
-        }
-    }
         
     var body: some View {
         NavigationStack {
@@ -58,37 +49,48 @@ struct HomeView: View {
                             print("Notifications tapped")
                         })
                     
-                    // Data Source Indicator
+                    // Connection status banner
+                    if !networkMonitor.isConnected {
+                        HStack(spacing: 8) {
+                            Image(systemName: "wifi.slash")
+                                .foregroundColor(.red)
+                            Text("No Internet Connection")
+                                .font(.callout)
+                                .foregroundColor(.red)
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(Color.red.opacity(0.1))
+                        .cornerRadius(8)
+                        .padding(.horizontal)
+                        .padding(.top, 4)
+                    }
+                    
+                    // Data Source Indicator (minimalist gray style)
                     if !homeViewModel.isLoading && !homeViewModel.recommendations.isEmpty {
                         HStack {
-                            Image(systemName: dataSourceIcon)
-                                .foregroundColor(dataSourceColor)
-                            Text(dataSourceText)
-                                .font(.caption)
-                                .foregroundColor(dataSourceColor)
+                            Spacer()
                             
-                            if homeViewModel.isRefreshing {
-                                ProgressView()
-                                    .scaleEffect(0.7)
-                                Text("Updating...")
-                                    .font(.caption2)
+                            HStack(spacing: 6) {
+                                Image(systemName: dataSourceIcon)
                                     .foregroundColor(.secondary)
+                                Text(dataSourceText)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                
+                                if homeViewModel.isRefreshing {
+                                    ProgressView()
+                                        .scaleEffect(0.7)
+                                    Text("Updating...")
+                                        .font(.caption2)
+                                        .foregroundColor(.secondary)
+                                }
                             }
                             
                             Spacer()
-                            
-                            // Debug button (optional, remove in production)
-                            Button(action: {
-                                homeViewModel.debugCache()
-                            }) {
-                                Image(systemName: "ladybug")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            }
                         }
                         .padding(.horizontal)
-                        .padding(.vertical, 8)
-                        .background(Color(.systemBackground).opacity(0.8))
+                        .padding(.top, 8)
                     }
 
                     ScrollView {
@@ -335,25 +337,6 @@ struct HomeView: View {
                     }
                 }
                 
-                // Floating connection status banner (only when data is loaded)
-                if !networkMonitor.isConnected && !homeViewModel.recommendations.isEmpty {
-                    VStack {
-                        HStack(spacing: 8) {
-                            Image(systemName: "wifi.slash")
-                                .foregroundColor(.orange)
-                            Text("Offline - Using cached data")
-                                .font(.caption)
-                                .foregroundColor(.orange)
-                        }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 8)
-                        .background(Color.orange.opacity(0.1))
-                        .cornerRadius(8)
-                        .padding(.top, 60)
-                        
-                        Spacer()
-                    }
-                }
             }
             .alert("Connection Required", isPresented: $showOfflineAlert) {
                 Button("OK", role: .cancel) {}

--- a/Swifties/Views/UserInfoView.swift
+++ b/Swifties/Views/UserInfoView.swift
@@ -1,10 +1,3 @@
-//
-//  UserInfoView.swift
-//  Swifties
-//
-//  Created by
-//
-
 import SwiftUI
 import FirebaseAuth
 import FirebaseFirestore
@@ -36,15 +29,6 @@ struct UserInfoView: View {
         }
     }
     
-    private var dataSourceColor: Color {
-        switch viewModel.dataSource {
-        case .memoryCache: return .purple
-        case .localStorage: return .blue
-        case .network: return .green
-        case .none: return .secondary
-        }
-    }
-    
     var body: some View {
         ZStack {
             Color("appPrimary").ignoresSafeArea()
@@ -60,37 +44,48 @@ struct UserInfoView: View {
                     dismiss()
                 })
                 
-                // Data Source Indicator
+                // Connection status banner (placed before data source indicator)
+                if !networkMonitor.isConnected {
+                    HStack(spacing: 8) {
+                        Image(systemName: "wifi.slash")
+                            .foregroundColor(.red)
+                        Text("No Internet Connection")
+                            .font(.callout)
+                            .foregroundColor(.red)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(Color.red.opacity(0.1))
+                    .cornerRadius(8)
+                    .padding(.horizontal)
+                    .padding(.top, 4)
+                }
+                
+                // Data Source Indicator (minimalist gray style like HomeView)
                 if !viewModel.isLoading && !viewModel.availableEvents.isEmpty {
                     HStack {
-                        Image(systemName: dataSourceIcon)
-                            .foregroundColor(dataSourceColor)
-                        Text(dataSourceText)
-                            .font(.caption)
-                            .foregroundColor(dataSourceColor)
+                        Spacer()
                         
-                        if viewModel.isRefreshing {
-                            ProgressView()
-                                .scaleEffect(0.7)
-                            Text("Updating...")
-                                .font(.caption2)
+                        HStack(spacing: 6) {
+                            Image(systemName: dataSourceIcon)
                                 .foregroundColor(.secondary)
+                            Text(dataSourceText)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                            
+                            if viewModel.isRefreshing {
+                                ProgressView()
+                                    .scaleEffect(0.7)
+                                Text("Updating...")
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                            }
                         }
                         
                         Spacer()
-                        
-                        // Debug button (optional, remove in production)
-                        Button(action: {
-                            viewModel.debugCache()
-                        }) {
-                            Image(systemName: "ladybug")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
                     }
                     .padding(.horizontal)
-                    .padding(.vertical, 8)
-                    .background(Color(.systemBackground).opacity(0.8))
+                    .padding(.top, 8)
                 }
                 
                 // MARK: - Main Content Area
@@ -111,7 +106,7 @@ struct UserInfoView: View {
                     VStack(spacing: 20) {
                         Image(systemName: "wifi.slash")
                             .font(.system(size: 60))
-                            .foregroundColor(.orange)
+                            .foregroundColor(.gray.opacity(0.6))
                         
                         Text("No Internet Connection")
                             .font(.title3)
@@ -144,7 +139,7 @@ struct UserInfoView: View {
                             }
                             .padding(.horizontal, 32)
                             .padding(.vertical, 12)
-                            .background(Color.orange)
+                            .background(Color.gray.opacity(0.6))
                             .foregroundColor(.white)
                             .cornerRadius(10)
                         }
@@ -292,26 +287,6 @@ struct UserInfoView: View {
                         }
                         .padding(.top, 16)
                     }
-                }
-            }
-            
-            // Floating connection status banner at the top
-            if !networkMonitor.isConnected && (!viewModel.availableEvents.isEmpty || !viewModel.freeTimeSlots.isEmpty) {
-                VStack {
-                    HStack(spacing: 8) {
-                        Image(systemName: "wifi.slash")
-                            .foregroundColor(.orange)
-                        Text("Offline - Using cached data")
-                            .font(.caption)
-                            .foregroundColor(.orange)
-                    }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
-                    .background(Color.orange.opacity(0.1))
-                    .cornerRadius(8)
-                    .padding(.top, 60)
-                    
-                    Spacer()
                 }
             }
         }

--- a/Swifties/Views/WeeklyChallengeView.swift
+++ b/Swifties/Views/WeeklyChallengeView.swift
@@ -31,15 +31,6 @@ struct WeeklyChallengeView: View {
         }
     }
     
-    private var dataSourceColor: Color {
-        switch viewModel.dataSource {
-        case .memoryCache: return .purple
-        case .realmStorage: return .blue
-        case .network: return .green
-        case .none: return .secondary
-        }
-    }
-    
     var body: some View {
         ZStack {
             Color("appPrimary").ignoresSafeArea()
@@ -57,37 +48,48 @@ struct WeeklyChallengeView: View {
                     dismiss()
                 })
                 
-                // Data Source Indicator
+                // Connection status banner (placed before data source indicator)
+                if !networkMonitor.isConnected {
+                    HStack(spacing: 8) {
+                        Image(systemName: "wifi.slash")
+                            .foregroundColor(.red)
+                        Text("No Internet Connection")
+                            .font(.callout)
+                            .foregroundColor(.red)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(Color.red.opacity(0.1))
+                    .cornerRadius(8)
+                    .padding(.horizontal)
+                    .padding(.top, 4)
+                }
+                
+                // Data Source Indicator (minimalist gray style like HomeView)
                 if !viewModel.isLoading && viewModel.challengeEvent != nil {
                     HStack {
-                        Image(systemName: dataSourceIcon)
-                            .foregroundColor(dataSourceColor)
-                        Text(dataSourceText)
-                            .font(.caption)
-                            .foregroundColor(dataSourceColor)
+                        Spacer()
                         
-                        if viewModel.isRefreshing {
-                            ProgressView()
-                                .scaleEffect(0.7)
-                            Text("Updating...")
-                                .font(.caption2)
+                        HStack(spacing: 6) {
+                            Image(systemName: dataSourceIcon)
                                 .foregroundColor(.secondary)
+                            Text(dataSourceText)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                            
+                            if viewModel.isRefreshing {
+                                ProgressView()
+                                    .scaleEffect(0.7)
+                                Text("Updating...")
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                            }
                         }
                         
                         Spacer()
-                        
-                        // Debug button (optional, remove in production)
-                        Button(action: {
-                            viewModel.debugCache()
-                        }) {
-                            Image(systemName: "ladybug")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
                     }
                     .padding(.horizontal)
-                    .padding(.vertical, 8)
-                    .background(Color(.systemBackground).opacity(0.8))
+                    .padding(.top, 8)
                 }
                 
                 // MARK: - Main Content Area
@@ -109,7 +111,7 @@ struct WeeklyChallengeView: View {
                     VStack(spacing: 20) {
                         Image(systemName: "wifi.slash")
                             .font(.system(size: 60))
-                            .foregroundColor(.orange)
+                            .foregroundColor(.gray.opacity(0.6))
                         
                         Text("No Internet Connection")
                             .font(.title3)
@@ -142,7 +144,7 @@ struct WeeklyChallengeView: View {
                             }
                             .padding(.horizontal, 32)
                             .padding(.vertical, 12)
-                            .background(Color.orange)
+                            .background(Color.gray.opacity(0.6))
                             .foregroundColor(.white)
                             .cornerRadius(10)
                         }
@@ -466,26 +468,6 @@ struct WeeklyChallengeView: View {
                         }
                         .padding()
                     }
-                }
-            }
-            
-            // Floating connection status banner at the top
-            if !networkMonitor.isConnected && viewModel.challengeEvent != nil {
-                VStack {
-                    HStack(spacing: 8) {
-                        Image(systemName: "wifi.slash")
-                            .foregroundColor(.orange)
-                        Text("Offline - Using cached data")
-                            .font(.caption)
-                            .foregroundColor(.orange)
-                    }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
-                    .background(Color.orange.opacity(0.1))
-                    .cornerRadius(8)
-                    .padding(.top, 60)
-                    
-                    Spacer()
                 }
             }
         }


### PR DESCRIPTION
This pull request improves offline and registration handling, as well as the user interface for network and data source indicators across several SwiftUI views. The main changes include more robust detection and caching of user registration status, a unified and minimalist design for data source and connection banners, and enhanced offline messaging, especially in the profile view. Debug UI elements have also been removed for production readiness.

**Registration and Offline Handling Improvements:**

- The logic in `AuthViewModel` for determining if a user is a first-time user or returning user has been made more robust. It now checks both user-specific and global registration flags, caches results appropriately, and ensures pending offline registrations are synced when possible. This prevents issues when users register offline or reinstall the app. [[1]](diffhunk://#diff-99b26b414aef7c73913ce5638b9cbc0261b08691cef14c81a499b34f61949076L101-R107) [[2]](diffhunk://#diff-99b26b414aef7c73913ce5638b9cbc0261b08691cef14c81a499b34f61949076L114-R130)
- Registration status and profile checks now provide clearer, more consistent debug output and ensure local cache is updated in all relevant scenarios. [[1]](diffhunk://#diff-99b26b414aef7c73913ce5638b9cbc0261b08691cef14c81a499b34f61949076L128-R156) [[2]](diffhunk://#diff-99b26b414aef7c73913ce5638b9cbc0261b08691cef14c81a499b34f61949076L151-R165) [[3]](diffhunk://#diff-99b26b414aef7c73913ce5638b9cbc0261b08691cef14c81a499b34f61949076L161-R179)

**UI/UX Consistency for Network and Data Source Indicators:**

- The data source indicator in `EventListView`, `HomeView`, and `ProfileView` has been unified to a minimalist gray style, and the previously used color-coding has been removed for a cleaner look. [[1]](diffhunk://#diff-bae9c9b3e1e1e3deeef03da1ea225f157aa6097359b09de465854580860d5ebeL48-L56) [[2]](diffhunk://#diff-bae9c9b3e1e1e3deeef03da1ea225f157aa6097359b09de465854580860d5ebeL67-R85) [[3]](diffhunk://#diff-bae9c9b3e1e1e3deeef03da1ea225f157aa6097359b09de465854580860d5ebeR94-R99) [[4]](diffhunk://#diff-aceae07ac16be25a94ba3f8fbd627ed2f3f15f53258e6fefdd04f75c4efe0f0eL20-R20) [[5]](diffhunk://#diff-aceae07ac16be25a94ba3f8fbd627ed2f3f15f53258e6fefdd04f75c4efe0f0eL39-L47) [[6]](diffhunk://#diff-aceae07ac16be25a94ba3f8fbd627ed2f3f15f53258e6fefdd04f75c4efe0f0eL61-R79) [[7]](diffhunk://#diff-aceae07ac16be25a94ba3f8fbd627ed2f3f15f53258e6fefdd04f75c4efe0f0eR88-R93) [[8]](diffhunk://#diff-3a22c91c72b54f43c75424991fcb5c481af8ae51ed90c7a015fc5a9a960455f1R15-R17)
- Connection status banners are now consistently shown in red when offline, with improved placement and messaging. Duplicate or floating banners have been removed for clarity. [[1]](diffhunk://#diff-bae9c9b3e1e1e3deeef03da1ea225f157aa6097359b09de465854580860d5ebeL67-R85) [[2]](diffhunk://#diff-bae9c9b3e1e1e3deeef03da1ea225f157aa6097359b09de465854580860d5ebeL273-L291) [[3]](diffhunk://#diff-aceae07ac16be25a94ba3f8fbd627ed2f3f15f53258e6fefdd04f75c4efe0f0eL61-R79) [[4]](diffhunk://#diff-aceae07ac16be25a94ba3f8fbd627ed2f3f15f53258e6fefdd04f75c4efe0f0eL338-L356) [[5]](diffhunk://#diff-3a22c91c72b54f43c75424991fcb5c481af8ae51ed90c7a015fc5a9a960455f1L63-L79)

**Enhanced Offline Experience:**

- In `ProfileView`, a comprehensive offline state UI is now shown when no profile data is available and the device is offline, including a retry button and clear instructions for the user.

**Code Clean-up:**

- Debug buttons and related UI elements have been removed from the production UI in `EventListView` and `HomeView`. [[1]](diffhunk://#diff-bae9c9b3e1e1e3deeef03da1ea225f157aa6097359b09de465854580860d5ebeR94-R99) [[2]](diffhunk://#diff-aceae07ac16be25a94ba3f8fbd627ed2f3f15f53258e6fefdd04f75c4efe0f0eR88-R93)

These changes make the app more resilient to offline scenarios, improve the clarity of user feedback, and ensure a consistent, production-ready interface.

**References:**  
[[1]](diffhunk://#diff-99b26b414aef7c73913ce5638b9cbc0261b08691cef14c81a499b34f61949076L101-R107) [[2]](diffhunk://#diff-99b26b414aef7c73913ce5638b9cbc0261b08691cef14c81a499b34f61949076L114-R130) [[3]](diffhunk://#diff-99b26b414aef7c73913ce5638b9cbc0261b08691cef14c81a499b34f61949076L128-R156) [[4]](diffhunk://#diff-99b26b414aef7c73913ce5638b9cbc0261b08691cef14c81a499b34f61949076L151-R165) [[5]](diffhunk://#diff-99b26b414aef7c73913ce5638b9cbc0261b08691cef14c81a499b34f61949076L161-R179) [[6]](diffhunk://#diff-bae9c9b3e1e1e3deeef03da1ea225f157aa6097359b09de465854580860d5ebeL48-L56) [[7]](diffhunk://#diff-bae9c9b3e1e1e3deeef03da1ea225f157aa6097359b09de465854580860d5ebeL67-R85) [[8]](diffhunk://#diff-bae9c9b3e1e1e3deeef03da1ea225f157aa6097359b09de465854580860d5ebeR94-R99) [[9]](diffhunk://#diff-bae9c9b3e1e1e3deeef03da1ea225f157aa6097359b09de465854580860d5ebeL273-L291) [[10]](diffhunk://#diff-aceae07ac16be25a94ba3f8fbd627ed2f3f15f53258e6fefdd04f75c4efe0f0eL20-R20) [[11]](diffhunk://#diff-aceae07ac16be25a94ba3f8fbd627ed2f3f15f53258e6fefdd04f75c4efe0f0eL39-L47) [[12]](diffhunk://#diff-aceae07ac16be25a94ba3f8fbd627ed2f3f15f53258e6fefdd04f75c4efe0f0eL61-R79) [[13]](diffhunk://#diff-aceae07ac16be25a94ba3f8fbd627ed2f3f15f53258e6fefdd04f75c4efe0f0eR88-R93) [[14]](diffhunk://#diff-aceae07ac16be25a94ba3f8fbd627ed2f3f15f53258e6fefdd04f75c4efe0f0eL338-L356) [[15]](diffhunk://#diff-3a22c91c72b54f43c75424991fcb5c481af8ae51ed90c7a015fc5a9a960455f1R15-R17) [[16]](diffhunk://#diff-3a22c91c72b54f43c75424991fcb5c481af8ae51ed90c7a015fc5a9a960455f1L63-L79) [[17]](diffhunk://#diff-3a22c91c72b54f43c75424991fcb5c481af8ae51ed90c7a015fc5a9a960455f1R86-R133)