### PR TITLE
Analytic data to answer BQ 3 regarding the Mood Quiz

### DIFF
--- a/Swifties/Services/AnalyticsService.swift
+++ b/Swifties/Services/AnalyticsService.swift
@@ -22,44 +22,44 @@ enum MapViewSource: String {
 class AnalyticsService {
     static let shared = AnalyticsService()
     private init() {}
-
+    
     func logDiscoveryMethod(_ method: DiscoveryMethod) {
         Analytics.logEvent("activity_discovery_method", parameters: [
             "method": method.rawValue,
             "timestamp": Date().timeIntervalSince1970
         ])
     }
-
+    
     func logActivitySelection(activityId: String, discoveryMethod: DiscoveryMethod) {
         Analytics.logEvent("activity_selected", parameters: [
             "activity_id": activityId,
             "discovery_method": discoveryMethod.rawValue
         ])
     }
-
+    
     func logWishMeLuckUsed() {
         Analytics.logEvent("wish_me_luck_used", parameters: [
             "timestamp": Date().timeIntervalSince1970
         ])
     }
-
+    
     func logOutdoorIndoorPreference(_ percentage: Int) {
         Analytics.logEvent("outdoor_indoor_preference", parameters: [
             "percentage": percentage
         ])
     }
-
+    
     func setUserId(_ userId: String) {
         Analytics.setUserID(userId)
     }
-
+    
     func logError(_ error: Error, platform: String) {
         Analytics.logEvent("app_exception", parameters: [
             "error_type": String(describing: type(of: error)),
             "platform": platform
         ])
     }
-
+    
     func logCheckIn(activityId: String, category: String) {
         Analytics.logEvent("activity_check_in", parameters: [
             "activity_id": activityId,
@@ -108,8 +108,36 @@ class AnalyticsService {
         }
         Analytics.logEvent("map_interaction", parameters: parameters)
     }
+    
+    
+    // MARK: - Mood Quiz Analytics
+    
+    /// Logs when the user opens/starts the Mood Quiz screen
+    func logMoodQuizOpened(source: String = "home") {
+        Analytics.logEvent("mood_quiz_opened", parameters: [
+            "source": source,
+            "timestamp": Date().timeIntervalSince1970
+        ])
+    }
+    
+    /// Logs when the user answers the first question (quiz started)
+    func logMoodQuizStarted() {
+        Analytics.logEvent("mood_quiz_started", parameters: [
+            "timestamp": Date().timeIntervalSince1970
+        ])
+    }
+    
+    /// Logs when the user completes all quiz questions and clicks Finish
+    func logMoodQuizCompleted(resultCategory: String, totalScore: Int, isTied: Bool) {
+        Analytics.logEvent("mood_quiz_completed", parameters: [
+            "result_category": resultCategory,
+            "total_score": totalScore,
+            "is_tied": isTied,
+            "timestamp": Date().timeIntervalSince1970
+        ])
+    }
+    
 }
-
 func activarFirebase() {
     Analytics.setAnalyticsCollectionEnabled(true)
 }

--- a/Swifties/Views/MoodQuizView.swift
+++ b/Swifties/Views/MoodQuizView.swift
@@ -70,6 +70,10 @@ struct MoodQuizView: View {
             .task {
                 await viewModel.loadQuiz()
             }
+            .onAppear {
+                        // !!!! LOG WHEN USER OPENS THE QUIZ SCREEN
+                        AnalyticsService.shared.logMoodQuizOpened(source: "home")
+                    }
             .navigationDestination(isPresented: $showNews) {
                 NewsView()
             }


### PR DESCRIPTION
Closes #185 

This pull request adds analytics tracking for the Mood Quiz feature and improves the logging of user interactions throughout the quiz flow. The most significant changes include new analytics events for quiz open, start, and completion, as well as updates to the `MoodQuizViewModel` to trigger these events at the appropriate times. Additionally, some log messages have been clarified for better debugging.

**Mood Quiz Analytics Integration:**

* Added new methods to `AnalyticsService` to log when the Mood Quiz is opened, started (first question answered), and completed, including relevant parameters such as source, result category, and score.
* Triggered `logMoodQuizOpened` when the quiz screen appears in `MoodQuizView`, ensuring analytics capture every quiz session entry.
* Ensured `logMoodQuizStarted` is called only once when the user answers the first question, using a new `hasLoggedQuizStart` flag in `MoodQuizViewModel`. [[1]](diffhunk://#diff-bdf54345caae6c19a656f3b6c324dfd3a6dc20d2d41985ff96a0d6771948f5d9L28-R34) [[2]](diffhunk://#diff-bdf54345caae6c19a656f3b6c324dfd3a6dc20d2d41985ff96a0d6771948f5d9R289-R295)
* Called `logMoodQuizCompleted` when the user finishes the quiz, logging the result category, total score, and tie status.

**Code Quality and Logging Improvements:**

* Updated various print statements in `MoodQuizViewModel` to make logs clearer and more consistent, especially during result saving and retake flows. [[1]](diffhunk://#diff-bdf54345caae6c19a656f3b6c324dfd3a6dc20d2d41985ff96a0d6771948f5d9L388-R407) [[2]](diffhunk://#diff-bdf54345caae6c19a656f3b6c324dfd3a6dc20d2d41985ff96a0d6771948f5d9L409-R428) [[3]](diffhunk://#diff-bdf54345caae6c19a656f3b6c324dfd3a6dc20d2d41985ff96a0d6771948f5d9L425-R452) [[4]](diffhunk://#diff-bdf54345caae6c19a656f3b6c324dfd3a6dc20d2d41985ff96a0d6771948f5d9L487-R519)
* Reset `hasLoggedQuizStart` when clearing quiz state to ensure correct analytics tracking for subsequent quiz attempts.